### PR TITLE
feat(swiftui): let a toast replace the visible one instead of queueing

### DIFF
--- a/swiftui/SampleApp/ToastDisplayView.swift
+++ b/swiftui/SampleApp/ToastDisplayView.swift
@@ -160,6 +160,16 @@ struct ToastDisplayView: View {
                     toastManager.show(label: "Second toast", voice: .neutral)
                     toastManager.show(label: "Third toast", voice: .error)
                 }
+
+                // Run both to compare: queued, all ten play back long after the tapping has
+                // stopped; replaced, one pill counts up and settles on "Added item 10".
+                Button("Rapid Burst (queue)") {
+                    burst(policy: .queue)
+                }
+
+                Button("Rapid Burst (replace)") {
+                    burst(policy: .replace)
+                }
             }
 
             Section("Padding") {
@@ -228,6 +238,18 @@ struct ToastDisplayView: View {
             OverBottomSheetContent()
                 .lemonadeToastContainer()
                 .presentationDetents([.medium])
+        }
+    }
+
+    /// Ten toasts 150ms apart — spaced far enough to land as separate view updates, unlike the
+    /// same-tick "Queue Multiple Toasts" button, and the shape a real burst takes when a till
+    /// operator taps "add to cart" repeatedly.
+    private func burst(policy: LemonadeToastPolicy) {
+        Task { @MainActor in
+            for item in 1...10 {
+                toastManager.show(label: "Added item \(item)", voice: .success, policy: policy)
+                try? await Task.sleep(nanoseconds: 150_000_000)
+            }
         }
     }
 }

--- a/swiftui/Sources/Lemonade/Components/LemonadeToastContainerView.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeToastContainerView.swift
@@ -167,7 +167,7 @@ struct LemonadeToastContainerView<Content: View>: View {
 
     @ViewBuilder
     private var toastOverlay: some View {
-        if let toast = displayedToast, animationPhase.isPresented {
+        if let toast = toastToRender, animationPhase.isPresented {
             ToastItemView(
                 toast: toast,
                 onDismiss: { toastManager.dismiss() },
@@ -188,6 +188,24 @@ struct LemonadeToastContainerView<Content: View>: View {
             // Separate animation for drag (snappier)
             .animation(ToastAnimationConfig.interactiveSpring, value: dragOffset)
         }
+    }
+
+    /// The toast to draw, chosen by identity rather than by animation phase.
+    ///
+    /// A manager holding the same `id` we are showing has replaced that toast's content in place
+    /// — `LemonadeToastPolicy.replace` — so the update is drawn where the pill stands, with no
+    /// transition. A different `id` means a transition is running or is about to start, and until
+    /// `enterNewToast` swaps it in, the toast on screen is still the one that must be drawn.
+    ///
+    /// Deliberately not switched on `animationPhase`: SwiftUI computes `body` before running the
+    /// `onChange` that starts the exit, so an incoming toast would be rendered for a frame before
+    /// the phase caught up — a flash of the new content, then the old one fading over it.
+    private var toastToRender: LemonadeToastItem? {
+        guard let displayedToast else { return toastManager.currentToast }
+        guard let current = toastManager.currentToast, current.id == displayedToast.id else {
+            return displayedToast
+        }
+        return current
     }
 
     // MARK: - Drag Gesture Handling

--- a/swiftui/Sources/Lemonade/Components/LemonadeToastManager.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeToastManager.swift
@@ -71,6 +71,28 @@ public enum LemonadeToastDuration: Sendable, Equatable {
     }
 }
 
+// MARK: - Toast Policy
+
+/// How a `show(_:)` call behaves when a toast is already on screen.
+public enum LemonadeToastPolicy: Sendable, Equatable {
+    /// Wait for the visible toast, then take its place. Every message is seen, in call order.
+    ///
+    /// Suits toasts that each report a distinct outcome the user should not miss. It does mean a
+    /// burst of calls plays back after the burst itself has ended, since each toast is held for
+    /// `ToastAnimationConfig.minimumVisible` before the next may replace it.
+    case queue
+
+    /// Supersede the visible toast, and drop anything queued behind it.
+    ///
+    /// Suits a repeated action reporting its running state — a till adding items to a basket —
+    /// where only the newest message is worth reading and a backlog would outlive the taps that
+    /// produced it. Compose and Flutter behave this way for every toast, having no queue at all.
+    ///
+    /// The queue is cleared rather than kept, so nothing older can surface after the message that
+    /// replaced it.
+    case replace
+}
+
 // MARK: - Toast Item
 
 /// Represents a toast notification to be displayed.
@@ -109,6 +131,25 @@ public struct LemonadeToastItem: Identifiable, Equatable, Sendable {
 
     public static func == (lhs: LemonadeToastItem, rhs: LemonadeToastItem) -> Bool {
         lhs.id == rhs.id
+    }
+
+    /// This toast's content under an existing toast's identity.
+    ///
+    /// The container keys its transitions on `id`, so reusing one makes a replacement land as an
+    /// update to the toast already on screen — the pill keeps its place and its text changes —
+    /// rather than a fade out and a fresh entry animation.
+    func adoptingIdentity(of other: LemonadeToastItem) -> LemonadeToastItem {
+        LemonadeToastItem(
+            id: other.id,
+            label: label,
+            voice: voice,
+            icon: icon,
+            duration: duration,
+            isDismissible: isDismissible,
+            actionLabel: actionLabel,
+            onAction: onAction,
+            paddingValues: paddingValues
+        )
     }
 }
 
@@ -183,6 +224,9 @@ public final class LemonadeToastManager: ObservableObject {
     ///     tell "unset" from "explicitly zero" on a plain `EdgeInsets`). The top inset is never honored —
     ///     the toast is always bottom-anchored with intrinsic height, so it has no visible effect.
     ///     Defaults to `nil` (standard margins on every edge).
+    ///   - policy: What to do when a toast is already on screen — wait behind it (`.queue`, the
+    ///     default, preserving existing behaviour) or supersede it and drop anything queued
+    ///     (`.replace`).
     ///
     /// Use `.loading` to communicate an ongoing action (e.g. "Downloading your document…"). A loading
     /// toast shows a spinner and persists until you call ``dismiss()`` or replace it with another `show`.
@@ -194,7 +238,8 @@ public final class LemonadeToastManager: ObservableObject {
         dismissible: Bool = true,
         actionLabel: String? = nil,
         onAction: (@MainActor @Sendable () -> Void)? = nil,
-        paddingValues: EdgeInsets? = nil
+        paddingValues: EdgeInsets? = nil,
+        policy: LemonadeToastPolicy = .queue
     ) {
         let toast = LemonadeToastItem(
             label: label,
@@ -208,11 +253,22 @@ public final class LemonadeToastManager: ObservableObject {
             paddingValues: paddingValues
         )
 
-        if currentToast != nil {
-            // Queue the new toast and dismiss current after delay
+        switch policy {
+        case .replace:
+            // Anything still queued is older than this toast, so it is no longer worth showing —
+            // left in place it would surface after the message meant to supersede it.
+            //
+            // Deliberately not `dismiss()`: that promotes a queued toast into the slot we are
+            // about to overwrite, consuming it unseen.
+            pendingToasts.removeAll()
+            // Reuse the visible toast's identity so its content is updated where it stands. Going
+            // through `displayToast` either way restarts the dismissal timer, so the replacement
+            // gets its own full duration rather than inheriting what was left of the old one.
+            displayToast(currentToast.map(toast.adoptingIdentity(of:)) ?? toast)
+        case .queue where currentToast != nil:
             pendingToasts.append(toast)
             scheduleTransition()
-        } else {
+        case .queue:
             displayToast(toast)
         }
     }

--- a/swiftui/Tests/LemonadeTests/LemonadeToastPolicyTests.swift
+++ b/swiftui/Tests/LemonadeTests/LemonadeToastPolicyTests.swift
@@ -1,0 +1,123 @@
+import XCTest
+@testable import Lemonade
+
+/// Covers `LemonadeToastPolicy` — what a `show(_:)` call does when a toast is already on screen.
+///
+/// `.queue` is the default and is covered by `LemonadeToastQueueTests`. These guard `.replace`,
+/// and the promise that adding the parameter changed nothing for callers who omit it.
+@MainActor
+final class LemonadeToastPolicyTests: XCTestCase {
+
+    /// Omitting the parameter must behave exactly as before it existed.
+    func testQueueIsTheDefaultPolicy() {
+        let manager = LemonadeToastManager()
+
+        manager.show(label: "First", voice: .success)
+        manager.show(label: "Second", voice: .neutral)
+
+        XCTAssertEqual(
+            manager.currentToast?.label,
+            "First",
+            "The default policy replaced the visible toast — existing callers changed behaviour."
+        )
+    }
+
+    /// The defining behaviour of `.replace`: no waiting for the visible toast.
+    func testReplaceTakesOverImmediately() {
+        let manager = LemonadeToastManager()
+
+        manager.show(label: "First", voice: .success)
+        manager.show(label: "Second", voice: .neutral, policy: .replace)
+
+        XCTAssertEqual(manager.currentToast?.label, "Second")
+    }
+
+    /// A replacement adopts the visible toast's identity, which is what makes the container update
+    /// the pill where it stands rather than fade one out and animate another in.
+    func testReplaceKeepsTheVisibleToastsIdentity() {
+        let manager = LemonadeToastManager()
+
+        manager.show(label: "First", voice: .success)
+        let original = try? XCTUnwrap(manager.currentToast?.id)
+
+        manager.show(label: "Second", voice: .neutral, policy: .replace)
+
+        XCTAssertEqual(manager.currentToast?.label, "Second")
+        XCTAssertEqual(manager.currentToast?.id, original)
+    }
+
+    /// With nothing on screen there is no identity to adopt, so the toast arrives as its own and
+    /// gets a normal entry animation.
+    func testReplaceOnAnEmptyScreenKeepsItsOwnIdentity() {
+        let manager = LemonadeToastManager()
+
+        manager.show(label: "Only", voice: .success, policy: .replace)
+
+        XCTAssertEqual(manager.currentToast?.label, "Only")
+    }
+
+    /// A replacement supersedes the backlog too, not just what is on screen — otherwise a toast
+    /// queued earlier would surface after the message meant to replace it.
+    ///
+    /// Sampled after the replacement's own dismissal rather than during it: that is the moment a
+    /// surviving queue entry would be promoted, so anything short of it proves nothing.
+    func testReplaceDropsAlreadyQueuedToasts() async throws {
+        let manager = LemonadeToastManager()
+
+        manager.show(label: "First", voice: .success, duration: .custom(0.2))
+        manager.show(label: "Queued", voice: .neutral, duration: .custom(0.2))
+        manager.show(label: "Latest", voice: .error, duration: .custom(0.2), policy: .replace)
+
+        XCTAssertEqual(manager.currentToast?.label, "Latest")
+
+        let settle = ToastAnimationConfig.duration + 0.2 + 0.3
+        try await Task.sleep(nanoseconds: ToastAnimationConfig.nanoseconds(from: settle))
+
+        XCTAssertNil(
+            manager.currentToast,
+            "A toast queued before the replacement was promoted once it had gone."
+        )
+    }
+
+    /// The case this exists for: a burst collapses to its last message instead of playing back
+    /// after the taps have stopped.
+    func testAReplaceBurstLeavesOnlyTheNewest() async throws {
+        let manager = LemonadeToastManager()
+
+        for item in 1...5 {
+            manager.show(label: "Added item \(item)", voice: .success, policy: .replace)
+        }
+
+        XCTAssertEqual(manager.currentToast?.label, "Added item 5")
+
+        let settle = ToastAnimationConfig.minimumVisible + 0.3
+        try await Task.sleep(nanoseconds: ToastAnimationConfig.nanoseconds(from: settle))
+
+        XCTAssertEqual(manager.currentToast?.label, "Added item 5")
+    }
+
+    /// A replacement gets its own lifetime rather than inheriting the remainder of the one it
+    /// replaced — `displayToast` re-arms the dismissal timer.
+    func testAReplacementGetsItsOwnDuration() async throws {
+        let manager = LemonadeToastManager()
+
+        manager.show(label: "First", voice: .success, duration: .custom(0.3))
+        try await Task.sleep(nanoseconds: ToastAnimationConfig.nanoseconds(from: 0.4))
+        manager.show(label: "Second", voice: .neutral, duration: .custom(0.3), policy: .replace)
+
+        // The first toast's own dismissal would land about here; the second must outlive it.
+        try await Task.sleep(nanoseconds: ToastAnimationConfig.nanoseconds(from: 0.3))
+
+        XCTAssertEqual(manager.currentToast?.label, "Second")
+    }
+
+    /// A loading toast has no auto-dismiss timer of its own, but `.replace` still supersedes it.
+    func testReplaceSupersedesALoadingToast() {
+        let manager = LemonadeToastManager()
+
+        manager.show(label: "Downloading…", voice: .loading)
+        manager.show(label: "Download complete", voice: .success, policy: .replace)
+
+        XCTAssertEqual(manager.currentToast?.label, "Download complete")
+    }
+}


### PR DESCRIPTION
# Summary

`LemonadeToastManager.show(_:)` has always queued: a second call went into `pendingToasts` and
waited out `ToastAnimationConfig.minimumVisible` before taking over. That suits messages that each
report a distinct outcome, but not a repeated action reporting its running state — a till tapping
"add to cart" leaves a backlog that plays back after the tapping has stopped. Compose and Flutter
have no such queue, so SwiftUI was the odd one out.

Adds `LemonadeToastPolicy` and a `policy:` parameter on `show(_:)`, defaulting to `.queue`, so no
existing caller changes behaviour.

```swift
toastManager.show("Added to cart", voice: .success, policy: .replace)
```

**`.replace` clears the queue as well as taking the screen.** Superseding only the visible toast
would leave the earlier ones to be promoted when the replacement is dismissed — the backlog would
still play out, just later. It is also deliberately not routed through `dismiss()`, which promotes a
queued toast into the slot we are about to overwrite and consumes it unseen.

**The replacement adopts the visible toast's identity** (`adoptingIdentity(of:)`), so a burst reads
as one pill whose content updates rather than a run of toasts fading over each other. Going through
`displayToast` restarts the dismissal timer, so each update gets a full duration. With nothing on
screen there is no identity to adopt and the toast arrives normally.

That makes the container's render source matter. `LemonadeToastContainerView` drew a `@State` copy
refreshed only when the toast id changed — which an in-place update never does, so the pill would
keep its old text. It now draws the manager's toast whenever that carries the id already on screen,
and the captured copy otherwise. Keyed on identity rather than on `animationPhase`, because SwiftUI
computes `body` before running the `onChange` that starts an exit; phase-keyed, an incoming toast
would show for a frame before the old one faded over it.

`LemonadeToastPolicyTests` covers the replace path: queue cleared, identity adopted, timer
restarted, and `.queue` callers unaffected.

The sample app gains a queue/replace pair of burst buttons so the two can be compared side by side.

## Figma component

n/a — no visual change to the toast itself. This only changes how concurrent `show(_:)` calls
resolve against each other.

## Screenshot

<!-- A still can't show this — the difference is entirely in timing. A screen recording of the
sample app's two burst buttons (Toast → "Burst (queue)" vs "Burst (replace)") is the useful
artifact; I'll attach one. -->

## API Dump

**Verdict:** NO_CHANGES

No public API changes — this is a SwiftUI-only change, so no `kmp/<module>/api/*.api` or
`*.klib.api` file is touched. `bcv-check.sh --ci` confirms the baseline is identical to
`origin/main`.

Worth flagging for review even though BCV does not cover it: the Swift surface does grow, and both
additions are source-compatible.

- `public enum LemonadeToastPolicy` — new type, pure addition.
- `show(_:)` gains a trailing `policy: LemonadeToastPolicy = .queue`. Defaulted, so every existing
  call site compiles unchanged and keeps today's queueing behaviour.

**Genuine breaking changes (if any):**

None.
