### PR TITLE
fix(swiftui): keep the toast action on one line next to a long message

### DIFF
--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ToastDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ToastDisplay.kt
@@ -148,6 +148,23 @@ internal fun ToastDisplay() {
                         )
                     },
                 )
+                LemonadeUi.Button(
+                    label = "Long Label with Action",
+                    onClick = {
+                        toastState.show(
+                            label = "We couldn't sync your latest changes because the connection " +
+                                "dropped partway through",
+                            voice = ToastVoice.Error,
+                            actionLabel = "Try again",
+                            onAction = {
+                                toastState.show(
+                                    label = "Retrying…",
+                                    voice = ToastVoice.Neutral,
+                                )
+                            },
+                        )
+                    },
+                )
             }
         }
 

--- a/swiftui/SampleApp/ToastDisplayView.swift
+++ b/swiftui/SampleApp/ToastDisplayView.swift
@@ -92,6 +92,17 @@ struct ToastDisplayView: View {
                         }
                     )
                 }
+
+                Button("Long Label with Action") {
+                    toastManager.show(
+                        label: "We couldn't sync your latest changes because the connection dropped partway through",
+                        voice: .error,
+                        actionLabel: "Try again",
+                        onAction: { @MainActor in
+                            toastManager.show(label: "Retrying…", voice: .neutral)
+                        }
+                    )
+                }
             }
 
             Section("Custom Icon (Neutral Only)") {
@@ -225,6 +236,11 @@ struct ToastDisplayView: View {
                     LemonadeUi.Toast(label: "Success message", voice: .success, actionLabel: "Undo") {}
                     LemonadeUi.Toast(label: "Error message", voice: .error, actionLabel: "Retry") {}
                     LemonadeUi.Toast(label: "Neutral message", voice: .neutral, actionLabel: "View") {}
+                    LemonadeUi.Toast(
+                        label: "We couldn't sync your latest changes because the connection dropped partway through",
+                        voice: .error,
+                        actionLabel: "Try again"
+                    ) {}
                 }
                 .padding(.vertical, 8)
             }

--- a/swiftui/Sources/Lemonade/Components/LemonadeToast.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeToast.swift
@@ -139,18 +139,23 @@ private struct LemonadeToastView: View {
                 .font(LemonadeTypography.shared.bodySmallMedium.font)
                 .foregroundStyle(.content.contentAlwaysLight)
                 .lineLimit(nil)
+                .truncationMode(.tail)
                 .padding(.horizontal, .space.spacing100)
-                .layoutPriority(1)
 
             if let actionLabel, let onAction {
                 Button(action: onAction) {
                     Text(actionLabel)
                         .font(LemonadeTypography.shared.bodySmallMedium.font)
                         .foregroundStyle(.content.contentInfoAlwaysOnColor)
+                        .lineLimit(1)
+                        .fixedSize(horizontal: true, vertical: false)
                 }
                 .buttonStyle(.plain)
                 .padding(.vertical, .space.spacing100)
                 .contentShape(Rectangle())
+                // The action keeps its intrinsic width whatever the message does: the message wraps,
+                // and ellipsizes on the last line, rather than the action breaking across lines.
+                .layoutPriority(1)
             }
         }
         .padding(
@@ -223,6 +228,11 @@ struct LemonadeToast_Previews: PreviewProvider {
             LemonadeUi.Toast(label: "Changes saved", voice: .success, actionLabel: "Undo") {}
             LemonadeUi.Toast(label: "Something went wrong", voice: .error, actionLabel: "Retry") {}
             LemonadeUi.Toast(label: "Added to favorites", voice: .neutral, icon: .heart, actionLabel: "View") {}
+            LemonadeUi.Toast(
+                label: "We couldn't sync your latest changes because the connection dropped partway through",
+                voice: .error,
+                actionLabel: "Try again"
+            ) {}
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .padding()


### PR DESCRIPTION
# Summary

On iOS, the toast's message `Text` carried `layoutPriority(1)`, so in the `HStack` it claimed its
full ideal width first and left the action button with whatever remained. A long message squeezed
the action into a narrow column at the trailing edge — "Try again" rendered as `Try / y / ag / ain`.

The priority now sits on the action instead:

- the action label keeps its intrinsic width on a single line (`lineLimit(1)` +
  `fixedSize(horizontal: true, vertical: false)`, `layoutPriority(1)`);
- the message wraps into the space that's left, and ellipsizes on the last line
  (`truncationMode(.tail)`) when even that runs out — e.g. a single unbreakable word;
- short toasts are unchanged: the pill still hugs its content.

Android was already correct — Compose's `Row` measures the unweighted action at its intrinsic width
before handing the remainder to the weighted label — so no `kmp/ui` change was needed. Flutter's
toast has no action label at all.

Also adds a long-message-with-action case to the **iOS** and **Android** sample apps and to the
SwiftUI preview, so the regression is one tap away in both catalogues.

**Verified:** `swift build` + `swift test` (32 tests, 0 failures); `:composeApp:compileKotlinDesktop`,
`ktlintCheck` and `detektMetadataCommonMain` all green. The layout was confirmed by rendering the row
before and after at a 390pt width (screenshot below).

## Figma component

N/A — layout regression fix, no design change.

## Screenshot
<img width="360" alt="Simulator Screenshot - iPhone 17 - 2026-08-31 at 14 27 55" src="https://github.com/user-attachments/assets/31c8c5d6-0725-4141-9b35-319e632a7966" />


## API Dump

**Verdict:** NO_CHANGES

No public API changes. The fix is internal to `LemonadeToastView`'s `body`; the only other edits are
to the sample apps (`swiftui/SampleApp`, `kmp/composeApp` — unpublished) and a `#if DEBUG` preview.
`bcv-check.sh --ci` reports `NO_CHANGES — public API is identical`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
