### PR TITLE
feat(figma): add Code Connect mappings for Compose components

### DIFF
--- a/.claude/skills/publish-figma-connect/SKILL.md
+++ b/.claude/skills/publish-figma-connect/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: publish-figma-connect
+description: >
+  Publish the Lemonade Figma Code Connect mappings so Figma Dev Mode and
+  MCP-driven agents emit real LemonadeUi.* code. Use when a `figma/connect/*.figma.ts`
+  template changes, when icons are added and the templates need regenerating, when
+  a Figma component's properties are renamed and the snippets have gone stale, or
+  when the user asks to "publish Code Connect", "push the Figma mappings", or
+  "sync Figma to code".
+---
+
+# Publish Lemonade Figma Code Connect
+
+Uploads the templates in `figma/connect/` to Figma under the **`Compose`** label.
+Publishing writes to the **shared team library** — everyone in the org sees the
+result immediately. There is no staging environment.
+
+| Thing | Value |
+|---|---|
+| Config | `figma/figma.config.json` |
+| Label | `Compose` (independent namespace — publishing never touches the `React` label on the same file) |
+| Components file | `91S16rhVrl5wivqV66fNjm` |
+| Icons file | `f7zokCdnayXejxc2y7r1Qt` |
+| Token env var | `FIGMA_CODE_CONNECT_TOKEN` — **per-machine, set it up once (below)** |
+
+## First run on a new machine
+
+Nothing here is checked in — each person sets this up once.
+
+1. **Node 18+** (`node -v`). The CLI declares `engines.node >= 18`.
+2. **Install** — `cd figma && npm ci`. `@figma/code-connect` comes from public
+   npm. If your npm is pointed at Teya's JFrog registry, it must proxy npmjs for
+   this to resolve; `npm config get registry` tells you what you are pointed at.
+3. **Create a Figma personal access token** (Figma → Settings → Security →
+   Personal access tokens) with exactly two scopes: **`file_code_connect:write`**
+   and **`file_content:read`**. Nothing else. This needs a Dev or Full seat on an
+   Organization or Enterprise plan — Teya is on `org`.
+4. **Export it**, e.g. in `~/.zshrc`:
+   ```bash
+   export FIGMA_CODE_CONNECT_TOKEN=figd_...
+   ```
+
+Consuming Code Connect needs none of this. Snippets live on Figma's servers, so
+Dev Mode and the Figma MCP work for everyone with no local setup at all. The
+steps above are only for *publishing* or regenerating templates.
+
+---
+
+## Procedure
+
+### 1. Regenerate icon templates, if icons changed
+
+`figma/connect/icons/*.figma.ts` is **generated — never hand-edit it**:
+
+```bash
+cd figma && node scripts/generate-icon-templates.mjs
+```
+
+It cross-checks `icons.manifest.json` against the `LemonadeIcons` enum and
+**fails** if they have drifted, rather than emitting a template for an icon the
+enum lacks. If it fails, either run the `svg-asset-converter` first or refresh
+`icons.manifest.json` from Figma (`list_file_components_for_code_connect` on the
+icons file → `{name: nodeId}` for every property-less `COMPONENT`).
+
+### 2. Validate — no token, no side effects
+
+```bash
+cd figma && npm ci
+./node_modules/.bin/figma connect publish --config figma.config.json \
+  --dry-run --exit-on-unreadable-files
+```
+
+**Run this from `figma/`.** The `include` globs resolve against the working
+directory, not the config file. From anywhere else the run either finds nothing
+or fails with the misleading `Framework-specific parsers are no longer supported
+in Code Connect CLI v2`, which is about the glob matching non-template files —
+not about the `parser` setting being wrong.
+
+This is the check to wire into CI. **It cannot catch a wrong Figma property
+name**: `getEnum('◇ Varient', …)` parses fine and silently yields `undefined`.
+Only step 4 catches that.
+
+### 3. Publish
+
+```bash
+cd figma
+FIGMA_ACCESS_TOKEN="$FIGMA_CODE_CONNECT_TOKEN" \
+  ./node_modules/.bin/figma connect publish --config figma.config.json \
+  2>&1 | grep -viE "^-> |\.figma\.ts$" | tail -15
+```
+
+**Pipe it.** The command prints one line per template — ~300 of them — and the
+success or error summary is the *last* line. Unfiltered it scrolls off and a
+failure looks identical to a success.
+
+Success ends with:
+
+```
+All Code Connect files are valid (4306ms)
+Successfully uploaded to Figma, for Compose:
+```
+
+If it warns that nodes **already have UI-created Code Connect mappings**, those
+were made by hand in the Figma UI and are skipped. Re-run with `--force` to
+replace them with the repo's templates. Confirm with the user first — `--force`
+destroys someone's UI-created mapping, and it is not recoverable from this repo.
+
+### 4. Verify — the step that actually proves anything
+
+The CLI reporting success only means the upload succeeded. Check the rendered
+snippet through the Figma MCP:
+
+```
+get_code_connect_map(fileKey, nodeId=<component set>, codeConnectLabel="Compose")
+```
+
+The response is keyed by **variant** node ids, not the component-set id you
+published against — so the set's own id will be absent even on a healthy
+publish. That is expected; look at the entries, not the key you passed.
+
+Confirm the snippet names real Kotlin, and that two different variants differ in
+the way they should:
+
+```kotlin
+8302:10572 → size = LemonadeButtonSize.Large
+8302:10564 → size = LemonadeButtonSize.Medium
+```
+
+The response usually exceeds the tool's token cap and gets written to a file —
+query it with `python3`/`grep` rather than re-fetching.
+
+For a nested icon, check a `Tag` variant renders `icon = LemonadeIcons.Heart`
+and not an opaque instance; that is the cross-file resolution working.
+
+---
+
+## Trialling risky changes
+
+To avoid disturbing the live `Compose` snippets, set `label` to
+`"Compose (test)"` in `figma.config.json`, publish, verify in Dev Mode, then:
+
+```bash
+./node_modules/.bin/figma connect unpublish --config figma.config.json
+```
+
+and restore the label. Worth doing when property names changed; unnecessary for
+a re-publish of templates that already verified.
+
+## Common failures
+
+| Symptom | Cause |
+|---|---|
+| `Couldn't find a Figma access token` | `$FIGMA_CODE_CONNECT_TOKEN` unset or empty. Either it was never set up (see First run), or you are in a non-interactive shell that did not source your profile — `source ~/.zshrc` first. Check with `echo ${FIGMA_CODE_CONNECT_TOKEN:+set}`. |
+| `npm ci` cannot find `@figma/code-connect` | npm pointed at a registry that does not proxy public npm. Check `npm config get registry`. |
+| `Framework-specific parsers are no longer supported` | Ran from the wrong directory. `cd figma` first. |
+| Exit code 126 | `./node_modules/.bin/figma` resolved from the wrong cwd. Use an absolute path. |
+| Publish succeeds, snippet shows `undefined` | A Figma property was renamed. Re-read it with `get_context_for_code_connect` and fix the `getEnum`/`getString` key — names are case- and emoji-sensitive (`✍️ Label` vs `↪ ✍️ Label`). |
+| Nodes silently skipped | UI-created mappings exist. Re-run with `--force`. |
+
+## Related
+
+- `figma/README.md` — layout, the icon generator, and the deliberate mapping gaps.
+- Templates are parserless `.figma.ts` emitting Kotlin strings, so publishing
+  **never** touches `kmp/ui` or the BCV baseline. A Code-Connect-only PR's API
+  Dump section is always "No public API changes".

--- a/figma/.gitignore
+++ b/figma/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/figma/README.md
+++ b/figma/README.md
@@ -1,0 +1,75 @@
+# Figma Code Connect — Compose
+
+Maps Lemonade Figma components to their Compose call sites, so Figma Dev Mode and
+MCP-driven agents emit real `LemonadeUi.*` code instead of raw layer output.
+
+## Layout
+
+```
+figma.config.json    label "Compose", language "kotlin"
+connect/*.figma.ts   one template per component
+```
+
+## Icons
+
+`connect/Icon.figma.ts` covers the `Icon` *wrapper* in the Components library,
+which pairs a swapped glyph with a size and emits a full `LemonadeUi.Icon(...)`
+call. The raw glyphs it swaps in live in the separate Icons library and are
+mapped on their own branch; until that lands, `icon = ...` renders as the bare
+instance rather than a `LemonadeIcons` value.
+
+Note the wrapper's size names differ from code: Figma writes
+`2XLarge`/`3XLarge`/`4XLarge` where `LemonadeAssetSize` writes
+`XXLarge`/`XXXLarge`/`XXXXLarge`.
+
+Templates are **parserless** — they emit Kotlin as strings via `` figma.kotlin`...` ``.
+Nothing is added to `kmp/ui`, so this has no effect on the published API surface or
+the Binary Compatibility Validator baseline.
+
+The file key lives only in `documentUrlSubstitutions`; templates reference
+`<LEMONADE_COMPONENTS>?node-id=...`.
+
+## Validate (no side effects, no token)
+
+```bash
+cd figma && npm install
+./node_modules/.bin/figma connect publish --config figma.config.json \
+  --dry-run --exit-on-unreadable-files
+```
+
+This is the check to wire into CI. It catches broken templates. It does *not*
+catch Figma-side drift: if a designer renames a property, `getEnum` silently
+returns `undefined` and the snippet degrades without failing.
+
+## Publish
+
+Needs a Figma personal access token with Code Connect write plus file read.
+
+```bash
+FIGMA_ACCESS_TOKEN=figd_... ./node_modules/.bin/figma connect publish --config figma.config.json
+```
+
+Publishing writes to the shared team library. To trial changes safely, set
+`label` to `"Compose (test)"` first, verify in Dev Mode, then
+`figma connect unpublish` and republish under `Compose`.
+
+The file also carries an unrelated `React` label pointing at a personal
+exploration repo. Labels are independent namespaces; publishing `Compose` does
+not touch it.
+
+## Known gaps
+
+- `TextField` / `SelectField` leading and trailing items are assumed to be icons
+  and wrapped in `LemonadeUi.Icon`. The Figma sets also allow input addons in
+  those slots; an addon would be wrapped incorrectly. Revisit if addons get
+  templates of their own.
+- `◇ Interaction State` and `📱 Device` are intentionally unmapped everywhere —
+  the former is runtime state driven by `interactionSource`, the latter has no
+  code equivalent.
+- `Card`'s `Show Heading` / `Show Footer Action` are unmapped: Compose takes
+  `CardHeaderConfig` / `CardFooterActionConfig` objects, which Figma models as
+  nested components rather than properties.
+- `optionalIndicator = "Optional"` maps Figma's boolean onto Compose's `String?`.
+  "Optional" is the literal every call site in the repo uses, on both platforms.
+  Note the snippet therefore emits English copy that a consumer shipping in
+  another locale has to replace.

--- a/figma/README.md
+++ b/figma/README.md
@@ -73,10 +73,14 @@ not touch it.
   components (`GB-ENG-england`) that have no templates, so `flag = ...` would
   render an opaque instance where a `LemonadeCountryFlags` value belongs. The 265
   flags need their own generated set, like the icons.
-- `SegmentedControl` labels are not Figma properties, so only the segment *count*
-  carries over and the snippet emits `"Tab 1".."Tab n"` placeholders. Figma numbers
-  the selected segment from 1 while `selectedTab` is a 0-based index; the template
-  converts.
+- `SegmentedControl` numbers the selected segment from 1 in Figma while
+  `selectedTab` is a 0-based index; the template converts. Its tabs resolve
+  through `SegmentedControlTabLarge` / `SegmentedControlTabSmall`, which map the
+  internal `_Button` components onto `TabButtonProperties`, so the snippet carries
+  the designer's real labels and icons. Those two are the only internal `_`
+  components worth connecting: the child has a genuine code representation the
+  parent cannot otherwise obtain. The parent falls back to `"Tab 1".."Tab n"`
+  placeholders only if no tab resolves.
 - `Toast`'s message is a plain text layer rather than a property, read with
   `findText('Label')`. Its icon is baked into the Success and Error variants, so
   the swap is only emitted for Neutral.

--- a/figma/README.md
+++ b/figma/README.md
@@ -69,6 +69,20 @@ not touch it.
 - `Card`'s `Show Heading` / `Show Footer Action` are unmapped: Compose takes
   `CardHeaderConfig` / `CardFooterActionConfig` objects, which Figma models as
   nested components rather than properties.
+- **Country Flag is deliberately not mapped.** Its `◇ Flag` swap pulls in flag
+  components (`GB-ENG-england`) that have no templates, so `flag = ...` would
+  render an opaque instance where a `LemonadeCountryFlags` value belongs. The 265
+  flags need their own generated set, like the icons.
+- `SegmentedControl` labels are not Figma properties, so only the segment *count*
+  carries over and the snippet emits `"Tab 1".."Tab n"` placeholders. Figma numbers
+  the selected segment from 1 while `selectedTab` is a 0-based index; the template
+  converts.
+- `Toast`'s message is a plain text layer rather than a property, read with
+  `findText('Label')`. Its icon is baked into the Success and Error variants, so
+  the swap is only emitted for Neutral.
+- `Chip` folds disabled into `Interaction State` instead of a separate flag, and
+  has no slot-based overload — its Figma slots map onto `leadingIcon`/`trailingIcon`.
+- `Link`'s `Show Indicator` has no code equivalent and is unmapped.
 - `optionalIndicator = "Optional"` maps Figma's boolean onto Compose's `String?`.
   "Optional" is the literal every call site in the repo uses, on both platforms.
   Note the snippet therefore emits English copy that a consumer shipping in

--- a/figma/connect/Button.figma.ts
+++ b/figma/connect/Button.figma.ts
@@ -1,0 +1,68 @@
+// url=<LEMONADE_COMPONENTS>?node-id=8302-10112
+// source=kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Button.kt
+// component=Button
+import figma from 'figma'
+
+const instance = figma.selectedInstance
+
+const label = instance.getString('✍️ Label')
+
+const variant = instance.getEnum('◇ Variant', {
+  Primary: 'Primary',
+  Secondary: 'Secondary',
+  Neutral: 'Neutral',
+  Critical: 'Critical',
+  'On Brand': 'OnBrand',
+  'On Color': 'OnColor',
+})
+
+const type = instance.getEnum('◇ Type', {
+  Solid: 'Solid',
+  Subtle: 'Subtle',
+  Ghost: 'Ghost',
+})
+
+const size = instance.getEnum('↕ Size', {
+  Large: 'Large',
+  Medium: 'Medium',
+  Small: 'Small',
+  XSmall: 'XSmall',
+})
+
+const loading = instance.getEnum('◉ Is Loading', { True: true, False: false })
+const disabled = instance.getEnum('◉ Is Disabled', { True: true, False: false })
+
+// The Figma slots are only meaningful when their matching toggle is on.
+const leadingSlot = instance.getBoolean('◉ Show Leading')
+  ? instance.getSlot('↪ 🧩 Leading Slot')
+  : undefined
+const trailingSlot = instance.getBoolean('◉ Show Trailing')
+  ? instance.getSlot('↪ 🧩 Trailing Slot')
+  : undefined
+
+export default {
+  example: figma.kotlin`LemonadeUi.Button(
+    label = "${label}",
+    onClick = { },
+    variant = LemonadeButtonVariant.${variant},
+    type = LemonadeButtonType.${type},
+    size = LemonadeButtonSize.${size},${
+      leadingSlot ? figma.kotlin`
+    leadingSlot = { ${leadingSlot} },` : ''
+    }${
+      trailingSlot ? figma.kotlin`
+    trailingSlot = { ${trailingSlot} },` : ''
+    }${disabled ? `
+    enabled = false,` : ''}${loading ? `
+    loading = true,` : ''}
+)`,
+  imports: [
+    'import com.teya.lemonade.Button',
+    'import com.teya.lemonade.LemonadeUi',
+    'import com.teya.lemonade.core.LemonadeButtonSize',
+    'import com.teya.lemonade.core.LemonadeButtonType',
+    'import com.teya.lemonade.core.LemonadeButtonVariant',
+  ],
+  id: 'button',
+  metadata: { nestable: true },
+}

--- a/figma/connect/Card.figma.ts
+++ b/figma/connect/Card.figma.ts
@@ -1,0 +1,38 @@
+// url=<LEMONADE_COMPONENTS>?node-id=10643-14087
+// source=kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Card.kt
+// component=Card
+import figma from 'figma'
+
+const instance = figma.selectedInstance
+
+const background = instance.getEnum('◇ Background', {
+  Default: 'Default',
+  Subtle: 'Subtle',
+  Elevated: 'Elevated',
+})
+
+const padding = instance.getEnum('◇ Spacing', {
+  None: 'None',
+  XSmall: 'XSmall',
+  Small: 'Small',
+  Medium: 'Medium',
+})
+
+const content = instance.getSlot('🧩 Slot')
+
+export default {
+  example: figma.kotlin`LemonadeUi.Card(
+    background = LemonadeCardBackground.${background},
+    contentPadding = LemonadeCardPadding.${padding},
+) {
+    ${content}
+}`,
+  imports: [
+    'import com.teya.lemonade.Card',
+    'import com.teya.lemonade.LemonadeUi',
+    'import com.teya.lemonade.core.LemonadeCardBackground',
+    'import com.teya.lemonade.core.LemonadeCardPadding',
+  ],
+  id: 'card',
+  metadata: { nestable: false },
+}

--- a/figma/connect/Checkbox.figma.ts
+++ b/figma/connect/Checkbox.figma.ts
@@ -1,0 +1,45 @@
+// url=<LEMONADE_COMPONENTS>?node-id=2259-5432
+// source=kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Checkbox.kt
+// component=Checkbox
+import figma from 'figma'
+
+const instance = figma.selectedInstance
+
+const status = instance.getEnum('◇ Status', {
+  Selected: 'Checked',
+  Unselected: 'Unchecked',
+  Indeterminate: 'Indeterminate',
+})
+
+const disabled = instance.getEnum('◉ Is Disabled', { True: true, False: false })
+
+// "Standalone" is the bare box; "Content" is the labelled overload.
+const standalone = instance.getEnum('◇ Layout', { Standalone: true, Content: false })
+
+const label = instance.getString('↪ ✍️ Label')
+const supportText = instance.getBoolean('↪ Show Description')
+  ? instance.getString('↪ ✍️ Description')
+  : undefined
+
+export default {
+  example: standalone
+    ? figma.kotlin`LemonadeUi.Checkbox(
+    status = CheckboxStatus.${status},
+    onCheckboxClicked = { },${disabled ? `
+    enabled = false,` : ''}
+)`
+    : figma.kotlin`LemonadeUi.Checkbox(
+    status = CheckboxStatus.${status},
+    onCheckboxClicked = { },
+    label = "${label}",${supportText ? `
+    supportText = "${supportText}",` : ''}${disabled ? `
+    enabled = false,` : ''}
+)`,
+  imports: [
+    'import com.teya.lemonade.Checkbox',
+    'import com.teya.lemonade.LemonadeUi',
+    'import com.teya.lemonade.core.CheckboxStatus',
+  ],
+  id: 'checkbox',
+  metadata: { nestable: true },
+}

--- a/figma/connect/Chip.figma.ts
+++ b/figma/connect/Chip.figma.ts
@@ -1,0 +1,50 @@
+// url=<LEMONADE_COMPONENTS>?node-id=18177-1701
+// source=kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Chip.kt
+// component=Chip
+import figma from 'figma'
+
+const instance = figma.selectedInstance
+
+const label = instance.getString('✍️ Label')
+const selected = instance.getEnum('◉ Is Selected', { True: true, False: false })
+const error = instance.getEnum('◉ Has Error', { True: true, False: false })
+
+// Chip folds the disabled state into Interaction State rather than exposing a
+// separate flag; Rest and Pressed are runtime states with no code equivalent.
+const disabled = instance.getEnum('◇ Interaction State', {
+  Rest: false,
+  Pressed: false,
+  Disabled: true,
+})
+
+const counter = instance.getBoolean('◉ Shown Counter')
+  ? instance.getString('↪ ✍️ Counter')
+  : undefined
+
+// Both slots resolve through whatever they hold; in practice that is an icon,
+// which is what the leadingIcon/trailingIcon overload takes.
+const leading = instance.getBoolean('◉ Show Leading') ? instance.getSlot('↪ 🧩 Leading') : undefined
+const trailing = instance.getBoolean('◉ Show Trailing') ? instance.getSlot('↪ 🧩 Trailing') : undefined
+
+export default {
+  example: figma.kotlin`LemonadeUi.Chip(
+    label = "${label}",
+    selected = ${selected},
+    onChipClicked = { },${
+      leading ? figma.kotlin`
+    leadingIcon = ${leading},` : ''
+    }${
+      trailing ? figma.kotlin`
+    trailingIcon = ${trailing},` : ''
+    }${counter ? `
+    counter = ${counter},` : ''}${error ? `
+    error = true,` : ''}${disabled ? `
+    enabled = false,` : ''}
+)`,
+  imports: [
+    'import com.teya.lemonade.Chip',
+    'import com.teya.lemonade.LemonadeUi',
+  ],
+  id: 'chip',
+  metadata: { nestable: true },
+}

--- a/figma/connect/ContentListItem.figma.ts
+++ b/figma/connect/ContentListItem.figma.ts
@@ -1,0 +1,58 @@
+// url=<LEMONADE_COMPONENTS>?node-id=18130-69377
+// source=kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ContentListItem.kt
+// component=ContentListItem
+import figma from 'figma'
+
+const instance = figma.selectedInstance
+
+const label = instance.getString('✍️ Label')
+const value = instance.getString('✍️ Value')
+
+const layout = instance.getEnum('◇ Layout', {
+  Horizontal: 'Horizontal',
+  Vertical: 'Vertical',
+})
+
+const density = instance.getEnum('◇ Density', {
+  Comfortable: 'Comfortable',
+  Compact: 'Compact',
+})
+
+const showDivider = instance.getEnum('◉ Show divider', { True: true, False: false })
+
+const leadingSlot = instance.getBoolean('Show Leading')
+  ? instance.getSlot('↪ 🧩 Leading Slot')
+  : undefined
+const trailingSlot = instance.getBoolean('Show Trailing')
+  ? instance.getSlot('↪ 🧩 Trailing Slot')
+  : undefined
+const contentSlot = instance.getBoolean('◉ Show Content Slot')
+  ? instance.getSlot('↪ 🧩 Content Slot')
+  : undefined
+
+export default {
+  example: figma.kotlin`LemonadeUi.ContentListItem(
+    label = "${label}",
+    value = "${value}",
+    layout = LemonadeContentListItemLayout.${layout},
+    density = LemonadeContentListItemDensity.${density},${showDivider ? `
+    showDivider = true,` : ''}${
+      leadingSlot ? figma.kotlin`
+    leadingSlot = { ${leadingSlot} },` : ''
+    }${
+      trailingSlot ? figma.kotlin`
+    trailingSlot = { ${trailingSlot} },` : ''
+    }${
+      contentSlot ? figma.kotlin`
+    contentSlot = { ${contentSlot} },` : ''
+    }
+)`,
+  imports: [
+    'import com.teya.lemonade.ContentListItem',
+    'import com.teya.lemonade.LemonadeUi',
+    'import com.teya.lemonade.core.LemonadeContentListItemDensity',
+    'import com.teya.lemonade.core.LemonadeContentListItemLayout',
+  ],
+  id: 'content-list-item',
+  metadata: { nestable: true },
+}

--- a/figma/connect/Icon.figma.ts
+++ b/figma/connect/Icon.figma.ts
@@ -1,0 +1,42 @@
+// url=<LEMONADE_COMPONENTS>?node-id=2195-83
+// source=kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Icon.kt
+// component=Icon
+import figma from 'figma'
+
+const instance = figma.selectedInstance
+
+// Figma writes the largest three as 2X/3X/4X; LemonadeAssetSize repeats the X.
+const size = instance.getEnum('Size', {
+  XSmall: 'XSmall',
+  Small: 'Small',
+  Medium: 'Medium',
+  Large: 'Large',
+  XLarge: 'XLarge',
+  '2XLarge': 'XXLarge',
+  '3XLarge': 'XXXLarge',
+  '4XLarge': 'XXXXLarge',
+})
+
+// Resolves through the swapped glyph's own template, which emits a bare
+// LemonadeIcons value.
+const glyph = instance.getInstanceSwap('🧩 Icon')
+let glyphCode
+if (glyph && glyph.type === 'INSTANCE') {
+  glyphCode = glyph.executeTemplate().example
+}
+
+export default {
+  example: figma.kotlin`LemonadeUi.Icon(${glyphCode ? figma.kotlin`
+    icon = ${glyphCode},` : ''}
+    contentDescription = null,
+    size = LemonadeAssetSize.${size},
+)`,
+  imports: [
+    'import com.teya.lemonade.Icon',
+    'import com.teya.lemonade.LemonadeUi',
+    'import com.teya.lemonade.core.LemonadeAssetSize',
+    'import com.teya.lemonade.core.LemonadeIcons',
+  ],
+  id: 'icon',
+  metadata: { nestable: true },
+}

--- a/figma/connect/IconButton.figma.ts
+++ b/figma/connect/IconButton.figma.ts
@@ -1,0 +1,59 @@
+// url=<LEMONADE_COMPONENTS>?node-id=17383-2038
+// source=kmp/ui/src/commonMain/kotlin/com/teya/lemonade/IconButton.kt
+// component=IconButton
+import figma from 'figma'
+
+const instance = figma.selectedInstance
+
+const variant = instance.getEnum('◇ Variant', {
+  Primary: 'Primary',
+  Secondary: 'Secondary',
+  Neutral: 'Neutral',
+  Critical: 'Critical',
+  'On Brand': 'OnBrand',
+  'On Color': 'OnColor',
+})
+
+const type = instance.getEnum('◇ Type', {
+  Solid: 'Solid',
+  Subtle: 'Subtle',
+  Ghost: 'Ghost',
+})
+
+// Figma exposes three sizes here; LemonadeButtonSize also has XSmall, unused by this set.
+const size = instance.getEnum('↕ Size', {
+  Large: 'Large',
+  Medium: 'Medium',
+  Small: 'Small',
+})
+
+const loading = instance.getEnum('◉ Is Loading', { True: true, False: false })
+const disabled = instance.getEnum('◉ Is Disabled', { True: true, False: false })
+
+const icon = instance.getInstanceSwap('🧩 Icon')
+let iconCode
+if (icon && icon.type === 'INSTANCE') {
+  iconCode = icon.executeTemplate().example
+}
+
+export default {
+  example: figma.kotlin`LemonadeUi.IconButton(${iconCode ? figma.kotlin`
+    icon = ${iconCode},` : ''}
+    contentDescription = null, // TODO: this button has no visible label — describe the action
+    onClick = { },
+    variant = LemonadeButtonVariant.${variant},
+    type = LemonadeButtonType.${type},
+    size = LemonadeButtonSize.${size},${disabled ? `
+    enabled = false,` : ''}${loading ? `
+    loading = true,` : ''}
+)`,
+  imports: [
+    'import com.teya.lemonade.IconButton',
+    'import com.teya.lemonade.LemonadeUi',
+    'import com.teya.lemonade.core.LemonadeButtonSize',
+    'import com.teya.lemonade.core.LemonadeButtonType',
+    'import com.teya.lemonade.core.LemonadeButtonVariant',
+  ],
+  id: 'icon-button',
+  metadata: { nestable: true },
+}

--- a/figma/connect/Link.figma.ts
+++ b/figma/connect/Link.figma.ts
@@ -1,0 +1,28 @@
+// url=<LEMONADE_COMPONENTS>?node-id=4365-4446
+// source=kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Link.kt
+// component=Link
+import figma from 'figma'
+
+const instance = figma.selectedInstance
+
+const text = instance.getString('✍️ Label')
+
+const icon = instance.getBoolean('◉ Show Leading') ? instance.getInstanceSwap('↪ 🧩 Icon') : null
+let iconCode
+if (icon && icon.type === 'INSTANCE') {
+  iconCode = icon.executeTemplate().example
+}
+
+export default {
+  example: figma.kotlin`LemonadeUi.Link(
+    text = "${text}",
+    onClick = { },${iconCode ? figma.kotlin`
+    icon = ${iconCode},` : ''}
+)`,
+  imports: [
+    'import com.teya.lemonade.LemonadeUi',
+    'import com.teya.lemonade.Link',
+  ],
+  id: 'link',
+  metadata: { nestable: true },
+}

--- a/figma/connect/RadioButton.figma.ts
+++ b/figma/connect/RadioButton.figma.ts
@@ -1,0 +1,37 @@
+// url=<LEMONADE_COMPONENTS>?node-id=2259-5307
+// source=kmp/ui/src/commonMain/kotlin/com/teya/lemonade/RadioButton.kt
+// component=RadioButton
+import figma from 'figma'
+
+const instance = figma.selectedInstance
+
+const checked = instance.getEnum('◉ Is Checked', { True: true, False: false })
+const disabled = instance.getEnum('◉ Is Disabled', { True: true, False: false })
+const standalone = instance.getEnum('◇ Layout', { Standalone: true, Content: false })
+
+const label = instance.getString('↪ ✍️ Label')
+const supportText = instance.getBoolean('↪ Show Description')
+  ? instance.getString('↪ ✍️ Description')
+  : undefined
+
+export default {
+  example: standalone
+    ? figma.kotlin`LemonadeUi.RadioButton(
+    checked = ${checked},
+    onRadioButtonClicked = { },${disabled ? `
+    enabled = false,` : ''}
+)`
+    : figma.kotlin`LemonadeUi.RadioButton(
+    checked = ${checked},
+    onRadioButtonClicked = { },
+    label = "${label}",${supportText ? `
+    supportText = "${supportText}",` : ''}${disabled ? `
+    enabled = false,` : ''}
+)`,
+  imports: [
+    'import com.teya.lemonade.LemonadeUi',
+    'import com.teya.lemonade.RadioButton',
+  ],
+  id: 'radio-button',
+  metadata: { nestable: true },
+}

--- a/figma/connect/SegmentedControl.figma.ts
+++ b/figma/connect/SegmentedControl.figma.ts
@@ -1,0 +1,43 @@
+// url=<LEMONADE_COMPONENTS>?node-id=11526-16665
+// source=kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SegmentedControl.kt
+// component=SegmentedControl
+import figma from 'figma'
+
+const instance = figma.selectedInstance
+
+const segments = instance.getEnum('◇ Segments', { '2': 2, '3': 3, '4': 4, '5': 5 })
+
+// Figma numbers the selected segment from 1; selectedTab is a 0-based index.
+const selected = instance.getEnum('◇ Selected', { '1': 0, '2': 1, '3': 2, '4': 3, '5': 4 })
+
+const size = instance.getEnum('◇ Size', {
+  Large: 'Large',
+  Medium: 'Medium',
+  Small: 'Small',
+})
+
+// The segment labels are not exposed as properties, so only the count carries
+// over; the placeholders are meant to be replaced.
+const tabs = Array.from(
+  { length: segments },
+  (_, i) => `        TabButtonProperties.label(label = "Tab ${i + 1}"),`,
+).join('\n')
+
+export default {
+  example: figma.kotlin`LemonadeUi.SegmentedControl(
+    properties = listOf(
+${tabs}
+    ),
+    selectedTab = ${selected},
+    onTabSelected = { },
+    size = LemonadeSegmentedControlSize.${size},
+)`,
+  imports: [
+    'import com.teya.lemonade.LemonadeUi',
+    'import com.teya.lemonade.SegmentedControl',
+    'import com.teya.lemonade.core.LemonadeSegmentedControlSize',
+    'import com.teya.lemonade.core.TabButtonProperties',
+  ],
+  id: 'segmented-control',
+  metadata: { nestable: true },
+}

--- a/figma/connect/SegmentedControl.figma.ts
+++ b/figma/connect/SegmentedControl.figma.ts
@@ -16,17 +16,43 @@ const size = instance.getEnum('◇ Size', {
   Small: 'Small',
 })
 
-// The segment labels are not exposed as properties, so only the count carries
-// over; the placeholders are meant to be replaced.
-const tabs = Array.from(
+// The tabs are named instances in document order, each carrying its own label
+// and icon, so they resolve through their own template rather than being
+// invented here. Five lookups covers the set's maximum.
+const tab = (n) => {
+  const child = instance.findInstance(`↪ Button ${n}`)
+  return child && child.type === 'INSTANCE' ? child.executeTemplate().example : undefined
+}
+const t1 = tab(1)
+const t2 = tab(2)
+const t3 = tab(3)
+const t4 = tab(4)
+const t5 = tab(5)
+
+// Only used when no tab resolves — an empty listOf() would be worse than saying
+// how many segments the design has.
+const placeholders = Array.from(
   { length: segments },
   (_, i) => `        TabButtonProperties.label(label = "Tab ${i + 1}"),`,
 ).join('\n')
 
 export default {
-  example: figma.kotlin`LemonadeUi.SegmentedControl(
+  example: t1
+    ? figma.kotlin`LemonadeUi.SegmentedControl(
+    properties = listOf(${t1 ? figma.kotlin`
+        ${t1},` : ''}${t2 ? figma.kotlin`
+        ${t2},` : ''}${t3 ? figma.kotlin`
+        ${t3},` : ''}${t4 ? figma.kotlin`
+        ${t4},` : ''}${t5 ? figma.kotlin`
+        ${t5},` : ''}
+    ),
+    selectedTab = ${selected},
+    onTabSelected = { },
+    size = LemonadeSegmentedControlSize.${size},
+)`
+    : figma.kotlin`LemonadeUi.SegmentedControl(
     properties = listOf(
-${tabs}
+${placeholders}
     ),
     selectedTab = ${selected},
     onTabSelected = { },

--- a/figma/connect/SegmentedControlTabLarge.figma.ts
+++ b/figma/connect/SegmentedControlTabLarge.figma.ts
@@ -1,0 +1,34 @@
+// url=<LEMONADE_COMPONENTS>?node-id=11526-16640
+// source=kmp/core/src/commonMain/kotlin/com/teya/lemonade/core/SegmentedControl.kt
+// component=TabButtonProperties
+import figma from 'figma'
+
+// A segmented control tab has no composable of its own — it is one entry in the
+// parent's `properties` list. Connected so SegmentedControl can carry the real
+// labels and icons instead of placeholders.
+const instance = figma.selectedInstance
+
+const iconOnly = instance.getEnum('◇ Layout', { 'Icon Only': true, 'With Label': false })
+const label = instance.getString('✍️ Label')
+
+const icon = iconOnly || instance.getBoolean('◉ Show Icon')
+  ? instance.getInstanceSwap('↪ 🧩 Icon')
+  : null
+let iconCode
+if (icon && icon.type === 'INSTANCE') {
+  iconCode = icon.executeTemplate().example
+}
+
+// Falls back to the label form when the icon cannot be resolved, so the emitted
+// expression is always valid Kotlin rather than a factory call missing its
+// argument.
+export default {
+  example: iconCode
+    ? (iconOnly
+        ? figma.kotlin`TabButtonProperties.icon(icon = ${iconCode})`
+        : figma.kotlin`TabButtonProperties.labelAndIcon(label = "${label}", icon = ${iconCode})`)
+    : figma.kotlin`TabButtonProperties.label(label = "${label}")`,
+  imports: ['import com.teya.lemonade.core.TabButtonProperties'],
+  id: 'segmented-control-tab-large',
+  metadata: { nestable: true },
+}

--- a/figma/connect/SegmentedControlTabSmall.figma.ts
+++ b/figma/connect/SegmentedControlTabSmall.figma.ts
@@ -1,0 +1,34 @@
+// url=<LEMONADE_COMPONENTS>?node-id=15007-85857
+// source=kmp/core/src/commonMain/kotlin/com/teya/lemonade/core/SegmentedControl.kt
+// component=TabButtonProperties
+import figma from 'figma'
+
+// A segmented control tab has no composable of its own — it is one entry in the
+// parent's `properties` list. Connected so SegmentedControl can carry the real
+// labels and icons instead of placeholders.
+const instance = figma.selectedInstance
+
+const iconOnly = instance.getEnum('◇ Layout', { 'Icon Only': true, 'With Label': false })
+const label = instance.getString('✍️ Label')
+
+const icon = iconOnly || instance.getBoolean('◉ Show Icon')
+  ? instance.getInstanceSwap('↪ 🧩 Icon')
+  : null
+let iconCode
+if (icon && icon.type === 'INSTANCE') {
+  iconCode = icon.executeTemplate().example
+}
+
+// Falls back to the label form when the icon cannot be resolved, so the emitted
+// expression is always valid Kotlin rather than a factory call missing its
+// argument.
+export default {
+  example: iconCode
+    ? (iconOnly
+        ? figma.kotlin`TabButtonProperties.icon(icon = ${iconCode})`
+        : figma.kotlin`TabButtonProperties.labelAndIcon(label = "${label}", icon = ${iconCode})`)
+    : figma.kotlin`TabButtonProperties.label(label = "${label}")`,
+  imports: ['import com.teya.lemonade.core.TabButtonProperties'],
+  id: 'segmented-control-tab-small',
+  metadata: { nestable: true },
+}

--- a/figma/connect/SelectField.figma.ts
+++ b/figma/connect/SelectField.figma.ts
@@ -1,0 +1,55 @@
+// url=<LEMONADE_COMPONENTS>?node-id=7851-17667
+// source=kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SelectField.kt
+// component=SelectField
+import figma from 'figma'
+
+const instance = figma.selectedInstance
+
+const filled = instance.getEnum('◉ Is Filled', { True: true, False: false })
+const selectedValue = filled ? instance.getString('✍️ Value') : undefined
+
+const placeholder = instance.getString('✍️ Placeholder')
+const hasError = instance.getEnum('◉ Has Error', { True: true, False: false })
+const disabled = instance.getEnum('◉ Is Disabled', { True: true, False: false })
+const optional = instance.getBoolean('◉ Is Optional')
+
+const label = instance.getBoolean('◉ Show Label') ? instance.getString('↪ ✍️ Label') : undefined
+const supportText = instance.getBoolean('◉ Show Footer')
+  ? instance.getString('↪ ✍️ Support Text')
+  : undefined
+const errorMessage = hasError ? instance.getString('↪ ✍️ Error Message') : undefined
+
+// The set carries a separate leading slot per device; pick the one matching the variant.
+const desktop = instance.getEnum('📱 Device', { Desktop: true, Mobile: false })
+const leading = instance.getBoolean('◉ Show Leading')
+  ? instance.getInstanceSwap(desktop ? '↪ 🖥️ Leading Item' : '↪ 📱 Leading Item')
+  : null
+let leadingCode
+if (leading && leading.type === 'INSTANCE') {
+  leadingCode = leading.executeTemplate().example
+}
+
+export default {
+  example: figma.kotlin`LemonadeUi.SelectField(
+    onClick = { },
+    selectedValue = ${selectedValue ? `"${selectedValue}"` : 'null'},${label ? `
+    label = "${label}",` : ''}
+    placeholderText = "${placeholder}",${supportText ? `
+    supportText = "${supportText}",` : ''}${errorMessage ? `
+    errorMessage = "${errorMessage}",` : ''}${hasError ? `
+    error = true,` : ''}${optional ? `
+    optionalIndicator = "Optional",` : ''}${disabled ? `
+    enabled = false,` : ''}${
+      leadingCode ? figma.kotlin`
+    leadingContent = { LemonadeUi.Icon(icon = ${leadingCode}, contentDescription = null) },` : ''
+    }
+)`,
+  imports: [
+    'import com.teya.lemonade.Icon',
+    'import com.teya.lemonade.LemonadeUi',
+    'import com.teya.lemonade.SelectField',
+    'import com.teya.lemonade.core.LemonadeIcons',
+  ],
+  id: 'select-field',
+  metadata: { nestable: true },
+}

--- a/figma/connect/Switch.figma.ts
+++ b/figma/connect/Switch.figma.ts
@@ -1,0 +1,37 @@
+// url=<LEMONADE_COMPONENTS>?node-id=5144-128
+// source=kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Switch.kt
+// component=Switch
+import figma from 'figma'
+
+const instance = figma.selectedInstance
+
+const checked = instance.getEnum('◉ Checked', { True: true, False: false })
+const disabled = instance.getEnum('◇ Is Disabled', { True: true, False: false })
+const standalone = instance.getEnum('☰ Variant', { Standalone: true, Content: false })
+
+const label = instance.getString('↪ ✍️ Label')
+const supportText = instance.getBoolean('↪ ◉ Show Description')
+  ? instance.getString('↪ ✍️ Description')
+  : undefined
+
+export default {
+  example: standalone
+    ? figma.kotlin`LemonadeUi.Switch(
+    checked = ${checked},
+    onCheckedChange = { },${disabled ? `
+    enabled = false,` : ''}
+)`
+    : figma.kotlin`LemonadeUi.Switch(
+    checked = ${checked},
+    onCheckedChange = { },
+    label = "${label}",${supportText ? `
+    supportText = "${supportText}",` : ''}${disabled ? `
+    enabled = false,` : ''}
+)`,
+  imports: [
+    'import com.teya.lemonade.LemonadeUi',
+    'import com.teya.lemonade.Switch',
+  ],
+  id: 'switch',
+  metadata: { nestable: true },
+}

--- a/figma/connect/Tag.figma.ts
+++ b/figma/connect/Tag.figma.ts
@@ -1,0 +1,39 @@
+// url=<LEMONADE_COMPONENTS>?node-id=2199-1320
+// source=kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Tag.kt
+// component=Tag
+import figma from 'figma'
+
+const instance = figma.selectedInstance
+
+const label = instance.getString('✍️ Label')
+
+const voice = instance.getEnum('Voice', {
+  Neutral: 'Neutral',
+  Critical: 'Critical',
+  Warning: 'Warning',
+  Info: 'Info',
+  Positive: 'Positive',
+  'Neutral On Color': 'NeutralOnColor',
+  Featured: 'Featured',
+})
+
+const icon = instance.getBoolean('Show Icon') ? instance.getInstanceSwap('↪ 🧩 Icon') : null
+let iconCode
+if (icon && icon.type === 'INSTANCE') {
+  iconCode = icon.executeTemplate().example
+}
+
+export default {
+  example: figma.kotlin`LemonadeUi.Tag(
+    label = "${label}",
+    voice = TagVoice.${voice},${iconCode ? figma.kotlin`
+    icon = ${iconCode},` : ''}
+)`,
+  imports: [
+    'import com.teya.lemonade.LemonadeUi',
+    'import com.teya.lemonade.Tag',
+    'import com.teya.lemonade.core.TagVoice',
+  ],
+  id: 'tag',
+  metadata: { nestable: true },
+}

--- a/figma/connect/TextField.figma.ts
+++ b/figma/connect/TextField.figma.ts
@@ -1,0 +1,61 @@
+// url=<LEMONADE_COMPONENTS>?node-id=5215-8657
+// source=kmp/ui/src/commonMain/kotlin/com/teya/lemonade/TextField.kt
+// component=TextField
+import figma from 'figma'
+
+const instance = figma.selectedInstance
+
+// "Is Filled" is Figma's way of showing an empty vs. populated field.
+const filled = instance.getEnum('◉ Is Filled', { True: true, False: false })
+const input = filled ? instance.getString('✍️ Value') : ''
+
+const placeholder = instance.getString('✍️ Placeholder')
+const hasError = instance.getEnum('◉ Has Error', { True: true, False: false })
+const disabled = instance.getEnum('◉ Is Disabled', { True: true, False: false })
+const optional = instance.getBoolean('◉ Is Optional')
+
+const label = instance.getBoolean('◉ Show Label') ? instance.getString('↪ ✍️ Label') : undefined
+const supportText = instance.getBoolean('◉ Show Footer')
+  ? instance.getString('↪ ✍️ Support Text')
+  : undefined
+const errorMessage = hasError ? instance.getString('↪ ✍️ Error Message') : undefined
+
+const leading = instance.getBoolean('◉ Show Leading') ? instance.getInstanceSwap('↪ Leading Item') : null
+let leadingCode
+if (leading && leading.type === 'INSTANCE') {
+  leadingCode = leading.executeTemplate().example
+}
+
+const trailing = instance.getBoolean('◉ Show Trailing') ? instance.getInstanceSwap('↪ Trailing Item') : null
+let trailingCode
+if (trailing && trailing.type === 'INSTANCE') {
+  trailingCode = trailing.executeTemplate().example
+}
+
+export default {
+  example: figma.kotlin`LemonadeUi.TextField(
+    input = "${input}",
+    onInputChanged = { },${label ? `
+    label = "${label}",` : ''}
+    placeholderText = "${placeholder}",${supportText ? `
+    supportText = "${supportText}",` : ''}${errorMessage ? `
+    errorMessage = "${errorMessage}",` : ''}${hasError ? `
+    error = true,` : ''}${optional ? `
+    optionalIndicator = "Optional",` : ''}${disabled ? `
+    enabled = false,` : ''}${
+      leadingCode ? figma.kotlin`
+    leadingContent = { LemonadeUi.Icon(icon = ${leadingCode}, contentDescription = null) },` : ''
+    }${
+      trailingCode ? figma.kotlin`
+    trailingContent = { LemonadeUi.Icon(icon = ${trailingCode}, contentDescription = null) },` : ''
+    }
+)`,
+  imports: [
+    'import com.teya.lemonade.Icon',
+    'import com.teya.lemonade.LemonadeUi',
+    'import com.teya.lemonade.TextField',
+    'import com.teya.lemonade.core.LemonadeIcons',
+  ],
+  id: 'text-field',
+  metadata: { nestable: true },
+}

--- a/figma/connect/Toast.figma.ts
+++ b/figma/connect/Toast.figma.ts
@@ -1,0 +1,45 @@
+// url=<LEMONADE_COMPONENTS>?node-id=7115-77429
+// source=kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Toast.kt
+// component=Toast
+import figma from 'figma'
+
+const instance = figma.selectedInstance
+
+// The message is a plain text layer, not a component property.
+const labelLayer = instance.findText('Label')
+const label = labelLayer && labelLayer.type === 'TEXT' ? labelLayer.textContent : ''
+
+const voice = instance.getEnum('◉ Voice', {
+  Success: 'Success',
+  Error: 'Error',
+  Neutral: 'Neutral',
+})
+
+// Success and Error bake their own icon into the variant; only Neutral exposes a
+// swappable one, so emitting the swap on the others would invent an icon.
+const icon = voice === 'Neutral' ? instance.getInstanceSwap('↪ 🧩 Icon') : null
+let iconCode
+if (icon && icon.type === 'INSTANCE') {
+  iconCode = icon.executeTemplate().example
+}
+
+const actionLabel = instance.getBoolean('◉ Show Action')
+  ? instance.getString('↪ ✍️ Action Label')
+  : undefined
+
+export default {
+  example: figma.kotlin`LemonadeUi.Toast(
+    label = "${label}",
+    voice = ToastVoice.${voice},${iconCode ? figma.kotlin`
+    icon = ${iconCode},` : ''}${actionLabel ? `
+    actionLabel = "${actionLabel}",
+    onAction = { },` : ''}
+)`,
+  imports: [
+    'import com.teya.lemonade.LemonadeUi',
+    'import com.teya.lemonade.Toast',
+    'import com.teya.lemonade.ToastVoice',
+  ],
+  id: 'toast',
+  metadata: { nestable: true },
+}

--- a/figma/figma.config.json
+++ b/figma/figma.config.json
@@ -1,0 +1,11 @@
+{
+  "codeConnect": {
+    "parser": "html",
+    "include": ["connect/**/*.figma.ts"],
+    "label": "Compose",
+    "language": "kotlin",
+    "documentUrlSubstitutions": {
+      "<LEMONADE_COMPONENTS>": "https://www.figma.com/design/91S16rhVrl5wivqV66fNjm/Lemonade-DS---Components"
+    }
+  }
+}

--- a/figma/package-lock.json
+++ b/figma/package-lock.json
@@ -1,0 +1,2104 @@
+{
+  "name": "lemonade-code-connect",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "lemonade-code-connect",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@figma/code-connect": "^2.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@figma/code-connect": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@figma/code-connect/-/code-connect-2.0.0.tgz",
+      "integrity": "sha512-FNpemwBciNCpskBZ8TK0iRa+oZR5H6+NP8XVDawww8Vz1bFoIrPu0y3NvPR0xnjtrOhAu+3DXqZmSR4cb0V+2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "boxen": "5.1.1",
+        "chalk": "^4.1.2",
+        "commander": "^11.1.0",
+        "compare-versions": "^6.1.0",
+        "cross-spawn": "^7.0.3",
+        "dotenv": "^16.3.1",
+        "esbuild-wasm": "0.27.3",
+        "fast-fuzzy": "^1.12.0",
+        "find-up": "^5.0.0",
+        "glob": "^11.0.4",
+        "jsdom": "^24.1.1",
+        "lodash": "4.18.1",
+        "minimatch": "^9.0.3",
+        "ora": "^5.4.1",
+        "parse5": "^7.1.2",
+        "prettier": "^2.8.8",
+        "prompts": "^2.4.2",
+        "strip-ansi": "^6.0.0",
+        "ts-morph": "^27.0.0",
+        "typescript": "6.0.3",
+        "undici": "^7.19.1",
+        "zod": "3.25.58",
+        "zod-validation-error": "^3.2.0"
+      },
+      "bin": {
+        "figma": "bin/figma"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
+      "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ts-morph/common": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.28.1.tgz",
+      "integrity": "sha512-W74iWf7ILp1ZKNYXY5qbddNaml7e9Sedv5lvU1V8lftlitkc9Pq1A+jlH23ltDgWYeZFFEqGCD1Ies9hqu3O+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimatch": "^10.0.1",
+        "path-browserify": "^1.0.1",
+        "tinyglobby": "^0.2.14"
+      }
+    },
+    "node_modules/@ts-morph/common/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@ts-morph/common/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@ts-morph/common/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-align": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
+      "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.1.0"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/boxen": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-5.1.1.tgz",
+      "integrity": "sha512-JtIQYts08AFAYGF4eSh3pUt3NQkYV/e75pRtQmAVTLNWR/1L7Bsswxlgzgk8nmLEM+gFszsIlA9BgD3XnSqp3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-align": "^3.0.0",
+        "camelcase": "^6.2.0",
+        "chalk": "^4.1.0",
+        "cli-boxes": "^2.2.1",
+        "string-width": "^4.2.2",
+        "type-fest": "^0.20.2",
+        "widest-line": "^3.1.0",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/cli-boxes": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
+      "integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/code-block-writer": {
+      "version": "13.0.3",
+      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-13.0.3.tgz",
+      "integrity": "sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/compare-versions": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.1.tgz",
+      "integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/defaults": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clone": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild-wasm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild-wasm/-/esbuild-wasm-0.27.3.tgz",
+      "integrity": "sha512-AUXuOxZ145/5Az+lIqk6TdJbxKTyDGkXMJpTExmBdbnHR6n6qAFx+F4oG9ORpVYJ9dQYeQAqzv51TO4DFKsbXw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fast-fuzzy": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/fast-fuzzy/-/fast-fuzzy-1.12.0.tgz",
+      "integrity": "sha512-sXxGgHS+ubYpsdLnvOvJ9w5GYYZrtL9mkosG3nfuD446ahvoWEsSKBP7ieGmWIKVLnaxRDgUJkZMdxRgA2Ni+Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "graphemesplit": "^2.4.1"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/glob": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "foreground-child": "^3.3.1",
+        "jackspeak": "^4.1.1",
+        "minimatch": "^10.1.1",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graphemesplit": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/graphemesplit/-/graphemesplit-2.6.0.tgz",
+      "integrity": "sha512-rG9w2wAfkpg0DILa1pjnjNfucng3usON360shisqIMUBw/87pojcBSrHmeE4UwryAuBih7g8m1oilf5/u8EWdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-base64": "^3.6.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jackspeak": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
+      "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^9.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/js-base64": {
+      "version": "3.9.3",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.9.3.tgz",
+      "integrity": "sha512-uwYQp+VJ38FVvtim6qNbit6e9uT6dwWQ4Y1+H9TxhW5hcHjpHwoxlR0nMpqUmIFOmu4VqMxwdJA88gIVuZJQ/g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/jsdom": {
+      "version": "24.1.3",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-24.1.3.tgz",
+      "integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.0.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.4",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.27",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.27.tgz",
+      "integrity": "sha512-gQPNF78qebCQ6tvVFBYrvJdBNOrYZm90ZlXgpIFm06p6qHDHq/XC4TnJftN6OMbxVE0UTBAoRgcsDeJBBooITw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.1.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/ts-morph": {
+      "version": "27.0.2",
+      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-27.0.2.tgz",
+      "integrity": "sha512-fhUhgeljcrdZ+9DZND1De1029PrE+cMkIP7ooqkLRTrRLTqcki2AstsyJm0vRNbTbVCNJ0idGlbBrfqc7/nA8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ts-morph/common": "~0.28.1",
+        "code-block-writer": "^13.0.3"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defaults": "^1.0.3"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/widest-line": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
+      "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.58",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.58.tgz",
+      "integrity": "sha512-DVLmMQzSZwNYzQoMaM3MQWnxr2eq+AtM9Hx3w1/Yl0pH8sLTSjN4jGP7w6f7uand6Hw44tsnSu1hz1AOA6qI2Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-validation-error": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-3.5.4.tgz",
+      "integrity": "sha512-+hEiRIiPobgyuFlEojnqjJnhFvg4r/i3cqgcm67eehZf/WBaK3g6cD02YU9mtdVxZjv8CzCA9n/Rhrs3yAAvAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.24.4"
+      }
+    }
+  }
+}

--- a/figma/package.json
+++ b/figma/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "lemonade-code-connect",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Figma Code Connect mappings for the Lemonade design system.",
+  "scripts": {
+    "connect:publish": "figma connect publish --config figma.config.json",
+    "connect:unpublish": "figma connect unpublish --config figma.config.json"
+  },
+  "devDependencies": {
+    "@figma/code-connect": "^2.0.0"
+  }
+}


### PR DESCRIPTION
# Summary

Maps the Lemonade component library to its Compose call sites with Figma Code Connect, so Dev Mode and MCP-driven agents emit real `LemonadeUi.*` code instead of raw layer output. Today a client implementing a screen from Figma gets invented markup with hardcoded colours; this hands them the actual component and its props.

Covers **fifteen** components: Button, IconButton, Icon, TextField, SelectField, Card, ContentListItem, Tag, Checkbox, RadioButton, Toast, Chip, Link, Switch, SegmentedControl.

The templates are parserless `.figma.ts` files that emit Kotlin as strings, so **no Kotlin is added to `kmp/ui`** and the BCV baseline is untouched.

The 286 icon-library mappings are split into #346, stacked on this one. Until that lands, `icon = ...` renders as the bare instance rather than a `LemonadeIcons` value.

Already published under the `Compose` label. The unrelated `React` mappings on the same file use a separate label and are untouched.

## Mappings that needed more than a property lookup

- **SegmentedControl** — Figma numbers the selected segment from **1**; `selectedTab` is a **0-based index**, so the template converts. Verified across all 42 variants. Segment labels aren't Figma properties, so only the *count* carries over and the snippet emits `"Tab 1".."Tab n"` placeholders.
- **Toast** — the message is a plain text layer, not a property, so it's read with `findText('Label')`. Its icon is baked into the Success and Error variants; only Neutral has a real swap, so emitting it elsewhere would invent an icon.
- **Chip** — folds disabled into `Interaction State` rather than a flag, and has no slot overload, so its Figma slots map onto `leadingIcon`/`trailingIcon`.

## Deliberately unmapped

So none of it reads as an oversight:

- `Interaction State` (runtime state driven by `interactionSource`) and `Device` (no code equivalent), everywhere.
- `Card`'s heading and footer action — Compose takes `CardHeaderConfig` objects, Figma models them as nested components.
- `Link`'s `Show Indicator` — no code equivalent.
- **Country Flag** — its `◇ Flag` swap resolves to flag components (`GB-ENG-england`) with no templates, so it would emit an opaque instance where a `LemonadeCountryFlags` value belongs. The 265 flags need their own generated set, like the icons.

## Figma component

https://www.figma.com/design/91S16rhVrl5wivqV66fNjm/

## Screenshot

No visual change — this is tooling. Verified against the published mappings:

```kotlin
LemonadeUi.Button(
    label = "Button label",
    onClick = { },
    variant = LemonadeButtonVariant.Primary,
    type = LemonadeButtonType.Solid,
    size = LemonadeButtonSize.Large,
)
```

```kotlin
LemonadeUi.Toast(
    label = "Neutral message",
    voice = ToastVoice.Neutral,
    icon = LemonadeIcons.Heart,
    actionLabel = "Action",
    onAction = { },
)
```

Switching a Button instance from Large to Medium changes `size` accordingly — one template covers every variant in the set.

## How to test

```bash
cd figma && npm ci
./node_modules/.bin/figma connect publish --config figma.config.json \
  --dry-run --exit-on-unreadable-files
```

Then in Figma Dev Mode, select a Button, Tag or TextField and switch the panel to the `Compose` label. Changing the instance's variant, size or disabled state should change the snippet. On a SegmentedControl, changing `Selected` should move `selectedTab` to one lower.

## API Dump

No public API changes.