### PR TITLE
feat(figma): add Code Connect mappings for SwiftUI components

### DIFF
--- a/.claude/skills/publish-figma-connect/SKILL.md
+++ b/.claude/skills/publish-figma-connect/SKILL.md
@@ -17,8 +17,8 @@ result immediately. There is no staging environment.
 
 | Thing | Value |
 |---|---|
-| Config | `figma/figma.config.json` |
-| Label | `Compose` (independent namespace — publishing never touches the `React` label on the same file) |
+| Configs | `figma/figma.config.json` (Compose) and `figma/figma.swiftui.config.json` (SwiftUI) |
+| Labels | `Compose`, `SwiftUI` — each published separately from its own config. Neither touches the unrelated `React` label on the same file. |
 | Components file | `91S16rhVrl5wivqV66fNjm` |
 | Icons file | `f7zokCdnayXejxc2y7r1Qt` |
 | Token env var | `FIGMA_CODE_CONNECT_TOKEN` — **per-machine, set it up once (below)** |
@@ -84,10 +84,17 @@ Only step 4 catches that.
 
 ```bash
 cd figma
-FIGMA_ACCESS_TOKEN="$FIGMA_CODE_CONNECT_TOKEN" \
-  ./node_modules/.bin/figma connect publish --config figma.config.json \
-  2>&1 | grep -viE "^-> |\.figma\.ts$" | tail -15
+for cfg in figma.config.json figma.swiftui.config.json; do
+  FIGMA_ACCESS_TOKEN="$FIGMA_CODE_CONNECT_TOKEN" \
+    ./node_modules/.bin/figma connect publish --config "$cfg" \
+    2>&1 | grep -viE "^-> |\.figma\.ts$" | tail -8
+done
 ```
+
+Publish **both** labels, and never a platform's components without its icons.
+Figma resolves a nested icon by node; a label with no template for that node
+falls back to another label's, so a missing SwiftUI icon renders the *Kotlin*
+snippet inside a Swift call rather than rendering nothing.
 
 **Pipe it.** The command prints one line per template — ~300 of them — and the
 success or error summary is the *last* line. Unfiltered it scrolls off and a

--- a/figma/README.md
+++ b/figma/README.md
@@ -1,17 +1,45 @@
-# Figma Code Connect — Compose
+# Figma Code Connect
 
-Maps Lemonade Figma components to their Compose call sites, so Figma Dev Mode and
-MCP-driven agents emit real `LemonadeUi.*` code instead of raw layer output.
+Maps Lemonade Figma components to their call sites on **both platforms**, so Figma
+Dev Mode and MCP-driven agents emit real `LemonadeUi.*` code instead of raw layer
+output. One Figma component, two labels: `Compose` and `SwiftUI`.
 
 ## Layout
 
 ```
-figma.config.json          label "Compose", language "kotlin"
-icons.manifest.json        Figma icon name -> node id (refreshed from Figma)
-connect/*.figma.ts         one template per component, hand-written
-connect/icons/*.figma.ts   one per icon, GENERATED — do not edit
+figma.config.json                 label "Compose", language "kotlin"
+figma.swiftui.config.json         label "SwiftUI", language "swift"
+icons.manifest.json               Figma icon name -> node id (shared by both)
+connect/*.figma.ts                Compose components, hand-written
+connect/icons/*.figma.ts          Compose icons, GENERATED — do not edit
+connect-swiftui/*.figma.ts        SwiftUI components, hand-written
 scripts/generate-icon-templates.mjs
 ```
+
+Each label is published separately, with its own config:
+
+```bash
+./node_modules/.bin/figma connect publish --config figma.config.json
+./node_modules/.bin/figma connect publish --config figma.swiftui.config.json
+```
+
+**A platform's icons must be published alongside its components.** Figma resolves
+a nested icon by node, and when a label has no template for that node it falls
+back to another label's. A missing SwiftUI icon does not render blank — it
+renders the *Kotlin* snippet inside a Swift call (`icon: LemonadeIcons.Heart` in
+a `LemonadeUi.Tag`).
+
+The SwiftUI icon templates land on a follow-up branch. **Do not publish the
+`SwiftUI` label from this branch alone** — its icons will resolve to Compose's
+Kotlin values. The `Compose` label is unaffected.
+
+Swift rejects a trailing comma in an argument list, so the SwiftUI templates
+compose optional arguments with a **leading** comma. Kotlin permits either, so
+the Compose templates use the more usual trailing form.
+
+`TextField.input` is a `Binding` on SwiftUI, so the snippet emits
+`.constant("…")` — it keeps the designed text visible and compiles as written;
+swap it for real `@State` when wiring the screen up.
 
 ## Icons
 

--- a/figma/connect-swiftui/Button.figma.ts
+++ b/figma/connect-swiftui/Button.figma.ts
@@ -1,0 +1,62 @@
+// url=<LEMONADE_COMPONENTS>?node-id=8302-10112
+// source=swiftui/Sources/Lemonade/Components/LemonadeButton.swift
+// component=Button
+import figma from 'figma'
+
+const instance = figma.selectedInstance
+
+const label = instance.getString('✍️ Label')
+
+const variant = instance.getEnum('◇ Variant', {
+  Primary: 'primary',
+  Secondary: 'secondary',
+  Neutral: 'neutral',
+  Critical: 'critical',
+  'On Brand': 'onBrand',
+  'On Color': 'onColor',
+})
+
+const type = instance.getEnum('◇ Type', {
+  Solid: 'solid',
+  Subtle: 'subtle',
+  Ghost: 'ghost',
+})
+
+const size = instance.getEnum('↕ Size', {
+  Large: 'large',
+  Medium: 'medium',
+  Small: 'small',
+  XSmall: 'xSmall',
+})
+
+const loading = instance.getEnum('◉ Is Loading', { True: true, False: false })
+const disabled = instance.getEnum('◉ Is Disabled', { True: true, False: false })
+
+const leadingSlot = instance.getBoolean('◉ Show Leading')
+  ? instance.getSlot('↪ 🧩 Leading Slot')
+  : undefined
+const trailingSlot = instance.getBoolean('◉ Show Trailing')
+  ? instance.getSlot('↪ 🧩 Trailing Slot')
+  : undefined
+
+// Swift rejects a trailing comma in an argument list, so every optional
+// argument carries a leading comma instead.
+export default {
+  example: figma.swift`LemonadeUi.Button(
+    label: "${label}",
+    onClick: { }${
+      leadingSlot ? figma.swift`,
+    leadingSlot: { _ in ${leadingSlot} }` : ''
+    }${
+      trailingSlot ? figma.swift`,
+    trailingSlot: { _ in ${trailingSlot} }` : ''
+    },
+    variant: .${variant},
+    type: .${type},
+    size: .${size}${disabled ? `,
+    enabled: false` : ''}${loading ? `,
+    loading: true` : ''}
+)`,
+  id: 'button',
+  metadata: { nestable: true },
+}

--- a/figma/connect-swiftui/Card.figma.ts
+++ b/figma/connect-swiftui/Card.figma.ts
@@ -1,0 +1,32 @@
+// url=<LEMONADE_COMPONENTS>?node-id=10643-14087
+// source=swiftui/Sources/Lemonade/Components/LemonadeCard.swift
+// component=Card
+import figma from 'figma'
+
+const instance = figma.selectedInstance
+
+const background = instance.getEnum('◇ Background', {
+  Default: 'default',
+  Subtle: 'subtle',
+  Elevated: 'elevated',
+})
+
+const padding = instance.getEnum('◇ Spacing', {
+  None: 'none',
+  XSmall: 'xSmall',
+  Small: 'small',
+  Medium: 'medium',
+})
+
+const content = instance.getSlot('🧩 Slot')
+
+export default {
+  example: figma.swift`LemonadeUi.Card(
+    contentPadding: .${padding},
+    background: .${background}
+) {
+    ${content}
+}`,
+  id: 'card',
+  metadata: { nestable: false },
+}

--- a/figma/connect-swiftui/Checkbox.figma.ts
+++ b/figma/connect-swiftui/Checkbox.figma.ts
@@ -1,0 +1,38 @@
+// url=<LEMONADE_COMPONENTS>?node-id=2259-5432
+// source=swiftui/Sources/Lemonade/Components/LemonadeCheckbox.swift
+// component=Checkbox
+import figma from 'figma'
+
+const instance = figma.selectedInstance
+
+const status = instance.getEnum('◇ Status', {
+  Selected: 'checked',
+  Unselected: 'unchecked',
+  Indeterminate: 'indeterminate',
+})
+
+const disabled = instance.getEnum('◉ Is Disabled', { True: true, False: false })
+const standalone = instance.getEnum('◇ Layout', { Standalone: true, Content: false })
+
+const label = instance.getString('↪ ✍️ Label')
+const supportText = instance.getBoolean('↪ Show Description')
+  ? instance.getString('↪ ✍️ Description')
+  : undefined
+
+export default {
+  example: standalone
+    ? figma.swift`LemonadeUi.Checkbox(
+    status: .${status},
+    onCheckboxClicked: { }${disabled ? `,
+    enabled: false` : ''}
+)`
+    : figma.swift`LemonadeUi.Checkbox(
+    status: .${status},
+    onCheckboxClicked: { },
+    label: "${label}"${supportText ? `,
+    supportText: "${supportText}"` : ''}${disabled ? `,
+    enabled: false` : ''}
+)`,
+  id: 'checkbox',
+  metadata: { nestable: true },
+}

--- a/figma/connect-swiftui/ContentListItem.figma.ts
+++ b/figma/connect-swiftui/ContentListItem.figma.ts
@@ -1,0 +1,52 @@
+// url=<LEMONADE_COMPONENTS>?node-id=18130-69377
+// source=swiftui/Sources/Lemonade/Components/LemonadeContentListItem.swift
+// component=ContentListItem
+import figma from 'figma'
+
+const instance = figma.selectedInstance
+
+const label = instance.getString('✍️ Label')
+const value = instance.getString('✍️ Value')
+
+const layout = instance.getEnum('◇ Layout', {
+  Horizontal: 'horizontal',
+  Vertical: 'vertical',
+})
+
+const density = instance.getEnum('◇ Density', {
+  Comfortable: 'comfortable',
+  Compact: 'compact',
+})
+
+const showDivider = instance.getEnum('◉ Show divider', { True: true, False: false })
+
+const leadingSlot = instance.getBoolean('Show Leading')
+  ? instance.getSlot('↪ 🧩 Leading Slot')
+  : undefined
+const trailingSlot = instance.getBoolean('Show Trailing')
+  ? instance.getSlot('↪ 🧩 Trailing Slot')
+  : undefined
+const contentSlot = instance.getBoolean('◉ Show Content Slot')
+  ? instance.getSlot('↪ 🧩 Content Slot')
+  : undefined
+
+export default {
+  example: figma.swift`LemonadeUi.ContentListItem(
+    label: "${label}",
+    value: "${value}",
+    layout: .${layout}${showDivider ? `,
+    showDivider: true` : ''},
+    density: .${density}${
+      leadingSlot ? figma.swift`,
+    leadingSlot: { ${leadingSlot} }` : ''
+    }${
+      trailingSlot ? figma.swift`,
+    trailingSlot: { ${trailingSlot} }` : ''
+    }${
+      contentSlot ? figma.swift`,
+    contentSlot: { ${contentSlot} }` : ''
+    }
+)`,
+  id: 'content-list-item',
+  metadata: { nestable: true },
+}

--- a/figma/connect-swiftui/Icon.figma.ts
+++ b/figma/connect-swiftui/Icon.figma.ts
@@ -1,0 +1,34 @@
+// url=<LEMONADE_COMPONENTS>?node-id=2195-83
+// source=swiftui/Sources/Lemonade/Components/LemonadeIcon.swift
+// component=Icon
+import figma from 'figma'
+
+const instance = figma.selectedInstance
+
+// Figma writes the largest three as 2X/3X/4X; LemonadeUiIconSize repeats the x.
+const size = instance.getEnum('Size', {
+  XSmall: 'xSmall',
+  Small: 'small',
+  Medium: 'medium',
+  Large: 'large',
+  XLarge: 'xLarge',
+  '2XLarge': 'xxLarge',
+  '3XLarge': 'xxxLarge',
+  '4XLarge': 'xxxxLarge',
+})
+
+const glyph = instance.getInstanceSwap('🧩 Icon')
+let glyphCode
+if (glyph && glyph.type === 'INSTANCE') {
+  glyphCode = glyph.executeTemplate().example
+}
+
+export default {
+  example: figma.swift`LemonadeUi.Icon(${glyphCode ? figma.swift`
+    icon: ${glyphCode},` : ''}
+    contentDescription: nil,
+    size: .${size}
+)`,
+  id: 'icon',
+  metadata: { nestable: true },
+}

--- a/figma/connect-swiftui/IconButton.figma.ts
+++ b/figma/connect-swiftui/IconButton.figma.ts
@@ -1,0 +1,51 @@
+// url=<LEMONADE_COMPONENTS>?node-id=17383-2038
+// source=swiftui/Sources/Lemonade/Components/LemonadeIconButton.swift
+// component=IconButton
+import figma from 'figma'
+
+const instance = figma.selectedInstance
+
+const variant = instance.getEnum('◇ Variant', {
+  Primary: 'primary',
+  Secondary: 'secondary',
+  Neutral: 'neutral',
+  Critical: 'critical',
+  'On Brand': 'onBrand',
+  'On Color': 'onColor',
+})
+
+const type = instance.getEnum('◇ Type', {
+  Solid: 'solid',
+  Subtle: 'subtle',
+  Ghost: 'ghost',
+})
+
+const size = instance.getEnum('↕ Size', {
+  Large: 'large',
+  Medium: 'medium',
+  Small: 'small',
+})
+
+const loading = instance.getEnum('◉ Is Loading', { True: true, False: false })
+const disabled = instance.getEnum('◉ Is Disabled', { True: true, False: false })
+
+const icon = instance.getInstanceSwap('🧩 Icon')
+let iconCode
+if (icon && icon.type === 'INSTANCE') {
+  iconCode = icon.executeTemplate().example
+}
+
+export default {
+  example: figma.swift`LemonadeUi.IconButton(${iconCode ? figma.swift`
+    icon: ${iconCode},` : ''}
+    contentDescription: nil, // TODO: this button has no visible label — describe the action
+    onClick: { },
+    variant: .${variant},
+    type: .${type},
+    size: .${size}${disabled ? `,
+    enabled: false` : ''}${loading ? `,
+    loading: true` : ''}
+)`,
+  id: 'icon-button',
+  metadata: { nestable: true },
+}

--- a/figma/connect-swiftui/RadioButton.figma.ts
+++ b/figma/connect-swiftui/RadioButton.figma.ts
@@ -1,0 +1,33 @@
+// url=<LEMONADE_COMPONENTS>?node-id=2259-5307
+// source=swiftui/Sources/Lemonade/Components/LemonadeRadioButton.swift
+// component=RadioButton
+import figma from 'figma'
+
+const instance = figma.selectedInstance
+
+const checked = instance.getEnum('◉ Is Checked', { True: true, False: false })
+const disabled = instance.getEnum('◉ Is Disabled', { True: true, False: false })
+const standalone = instance.getEnum('◇ Layout', { Standalone: true, Content: false })
+
+const label = instance.getString('↪ ✍️ Label')
+const supportText = instance.getBoolean('↪ Show Description')
+  ? instance.getString('↪ ✍️ Description')
+  : undefined
+
+export default {
+  example: standalone
+    ? figma.swift`LemonadeUi.RadioButton(
+    checked: ${checked},
+    onRadioButtonClicked: { }${disabled ? `,
+    enabled: false` : ''}
+)`
+    : figma.swift`LemonadeUi.RadioButton(
+    checked: ${checked},
+    onRadioButtonClicked: { },
+    label: "${label}"${supportText ? `,
+    supportText: "${supportText}"` : ''}${disabled ? `,
+    enabled: false` : ''}
+)`,
+  id: 'radio-button',
+  metadata: { nestable: true },
+}

--- a/figma/connect-swiftui/SelectField.figma.ts
+++ b/figma/connect-swiftui/SelectField.figma.ts
@@ -1,0 +1,48 @@
+// url=<LEMONADE_COMPONENTS>?node-id=7851-17667
+// source=swiftui/Sources/Lemonade/Components/LemonadeSelectField.swift
+// component=SelectField
+import figma from 'figma'
+
+const instance = figma.selectedInstance
+
+const filled = instance.getEnum('◉ Is Filled', { True: true, False: false })
+const selectedValue = filled ? instance.getString('✍️ Value') : undefined
+
+const placeholder = instance.getString('✍️ Placeholder')
+const hasError = instance.getEnum('◉ Has Error', { True: true, False: false })
+const disabled = instance.getEnum('◉ Is Disabled', { True: true, False: false })
+const optional = instance.getBoolean('◉ Is Optional')
+
+const label = instance.getBoolean('◉ Show Label') ? instance.getString('↪ ✍️ Label') : undefined
+const supportText = instance.getBoolean('◉ Show Footer')
+  ? instance.getString('↪ ✍️ Support Text')
+  : undefined
+const errorMessage = hasError ? instance.getString('↪ ✍️ Error Message') : undefined
+
+const desktop = instance.getEnum('📱 Device', { Desktop: true, Mobile: false })
+const leading = instance.getBoolean('◉ Show Leading')
+  ? instance.getInstanceSwap(desktop ? '↪ 🖥️ Leading Item' : '↪ 📱 Leading Item')
+  : null
+let leadingCode
+if (leading && leading.type === 'INSTANCE') {
+  leadingCode = leading.executeTemplate().example
+}
+
+export default {
+  example: figma.swift`LemonadeUi.SelectField(
+    onClick: { },
+    selectedValue: ${selectedValue ? `"${selectedValue}"` : 'nil'},
+    placeholderText: "${placeholder}"${label ? `,
+    label: "${label}"` : ''}${optional ? `,
+    optionalIndicator: "Optional"` : ''}${supportText ? `,
+    supportText: "${supportText}"` : ''}${errorMessage ? `,
+    errorMessage: "${errorMessage}"` : ''}${hasError ? `,
+    error: true` : ''}${disabled ? `,
+    enabled: false` : ''}${
+      leadingCode ? figma.swift`,
+    leadingContent: { LemonadeUi.Icon(icon: ${leadingCode}, contentDescription: nil) }` : ''
+    }
+)`,
+  id: 'select-field',
+  metadata: { nestable: true },
+}

--- a/figma/connect-swiftui/Tag.figma.ts
+++ b/figma/connect-swiftui/Tag.figma.ts
@@ -1,0 +1,34 @@
+// url=<LEMONADE_COMPONENTS>?node-id=2199-1320
+// source=swiftui/Sources/Lemonade/Components/LemonadeTag.swift
+// component=Tag
+import figma from 'figma'
+
+const instance = figma.selectedInstance
+
+const label = instance.getString('✍️ Label')
+
+const voice = instance.getEnum('Voice', {
+  Neutral: 'neutral',
+  Critical: 'critical',
+  Warning: 'warning',
+  Info: 'info',
+  Positive: 'positive',
+  'Neutral On Color': 'neutralOnColor',
+  Featured: 'featured',
+})
+
+const icon = instance.getBoolean('Show Icon') ? instance.getInstanceSwap('↪ 🧩 Icon') : null
+let iconCode
+if (icon && icon.type === 'INSTANCE') {
+  iconCode = icon.executeTemplate().example
+}
+
+export default {
+  example: figma.swift`LemonadeUi.Tag(
+    label: "${label}"${iconCode ? figma.swift`,
+    icon: ${iconCode}` : ''},
+    voice: .${voice}
+)`,
+  id: 'tag',
+  metadata: { nestable: true },
+}

--- a/figma/connect-swiftui/TextField.figma.ts
+++ b/figma/connect-swiftui/TextField.figma.ts
@@ -1,0 +1,55 @@
+// url=<LEMONADE_COMPONENTS>?node-id=5215-8657
+// source=swiftui/Sources/Lemonade/Components/LemonadeTextField.swift
+// component=TextField
+import figma from 'figma'
+
+const instance = figma.selectedInstance
+
+const filled = instance.getEnum('◉ Is Filled', { True: true, False: false })
+const input = filled ? instance.getString('✍️ Value') : ''
+
+const placeholder = instance.getString('✍️ Placeholder')
+const hasError = instance.getEnum('◉ Has Error', { True: true, False: false })
+const disabled = instance.getEnum('◉ Is Disabled', { True: true, False: false })
+const optional = instance.getBoolean('◉ Is Optional')
+
+const label = instance.getBoolean('◉ Show Label') ? instance.getString('↪ ✍️ Label') : undefined
+const supportText = instance.getBoolean('◉ Show Footer')
+  ? instance.getString('↪ ✍️ Support Text')
+  : undefined
+const errorMessage = hasError ? instance.getString('↪ ✍️ Error Message') : undefined
+
+const leading = instance.getBoolean('◉ Show Leading') ? instance.getInstanceSwap('↪ Leading Item') : null
+let leadingCode
+if (leading && leading.type === 'INSTANCE') {
+  leadingCode = leading.executeTemplate().example
+}
+
+const trailing = instance.getBoolean('◉ Show Trailing') ? instance.getInstanceSwap('↪ Trailing Item') : null
+let trailingCode
+if (trailing && trailing.type === 'INSTANCE') {
+  trailingCode = trailing.executeTemplate().example
+}
+
+// `input` is a Binding. .constant keeps the designed text visible and compiles
+// as-is; swap it for a real @State binding when wiring the screen up.
+export default {
+  example: figma.swift`LemonadeUi.TextField(
+    input: .constant("${input}")${label ? `,
+    label: "${label}"` : ''}${optional ? `,
+    optionalIndicator: "Optional"` : ''}${supportText ? `,
+    supportText: "${supportText}"` : ''},
+    placeholderText: "${placeholder}"${errorMessage ? `,
+    errorMessage: "${errorMessage}"` : ''}${hasError ? `,
+    error: true` : ''}${disabled ? `,
+    enabled: false` : ''}${
+      leadingCode ? figma.swift`,
+    leadingContent: { LemonadeUi.Icon(icon: ${leadingCode}, contentDescription: nil) }` : ''
+    }${
+      trailingCode ? figma.swift`,
+    trailingContent: { LemonadeUi.Icon(icon: ${trailingCode}, contentDescription: nil) }` : ''
+    }
+)`,
+  id: 'text-field',
+  metadata: { nestable: true },
+}

--- a/figma/figma.swiftui.config.json
+++ b/figma/figma.swiftui.config.json
@@ -1,0 +1,12 @@
+{
+  "codeConnect": {
+    "parser": "html",
+    "include": ["connect-swiftui/**/*.figma.ts"],
+    "label": "SwiftUI",
+    "language": "swift",
+    "documentUrlSubstitutions": {
+      "<LEMONADE_COMPONENTS>": "https://www.figma.com/design/91S16rhVrl5wivqV66fNjm/Lemonade-DS---Components",
+      "<LEMONADE_ICONS>": "https://www.figma.com/design/f7zokCdnayXejxc2y7r1Qt/Lemonade-DS---Icons"
+    }
+  }
+}


### PR DESCRIPTION
# Summary

Mirrors the Compose component mappings for the SwiftUI SDK, so an iOS engineer implementing a Figma screen gets Swift instead of Kotlin. Same ten components.

SwiftUI publishes under its own **`SwiftUI`** label from a second config, `figma.swiftui.config.json`. Labels are independent namespaces, so this doesn't touch `Compose`.

**Stacked on #346.** Merge order: #345 → #346 → this → #349.

## Do not publish the SwiftUI label from this branch alone

Figma resolves a nested icon **by node**, and when a label has no template for that node it falls back to another label's rather than rendering nothing. The SwiftUI icons are in #349, so from this branch alone a Tag renders:

```swift
LemonadeUi.Tag(
    label: "Label",
    icon: LemonadeIcons.Heart,   // Kotlin, inside a Swift call
    voice: .positive
)
```

I hit this for real while verifying, so it isn't hypothetical. `Compose` is unaffected either way. The README carries the same warning, and #349 removes it once the icons land.

## Figma component

Same components file as #345 — only the label differs.

## Screenshot

No visual change. Verified against the published `SwiftUI` label:

```swift
LemonadeUi.Button(
    label: "Button label",
    onClick: { },
    variant: .primary,
    type: .solid,
    size: .large
)
```

## Notes for reviewers

- **Leading commas.** Swift rejects a trailing comma in an argument list, so the SwiftUI templates prepend the comma to each optional argument. The Compose templates keep the trailing form Kotlin allows. `connect-swiftui/Button.figma.ts` is where an invalid snippet would show up.
- **`TextField.input` is a `Binding`**, so the snippet emits `.constant("Value")`. It keeps the designed text visible and compiles as written, but a real screen wants `@State`. Flagging in case you'd rather it emitted `$text` and dropped the designed value.
- Same properties deliberately unmapped as on Compose: `Interaction State`, `Device`, and `Card`'s heading/footer action.

## How to test

```bash
cd figma && npm ci
./node_modules/.bin/figma connect publish --config figma.swiftui.config.json \
  --dry-run --exit-on-unreadable-files
```

## API Dump

No public API changes.