### PR TITLE
feat(dialog): use the semantic container radius

### DIFF
--- a/kmp/expressive/src/commonMain/kotlin/com/teya/lemonade/Dialog.kt
+++ b/kmp/expressive/src/commonMain/kotlin/com/teya/lemonade/Dialog.kt
@@ -66,7 +66,8 @@ import androidx.compose.ui.window.DialogProperties
  *
  * ## Design Notes
  *
- * - The dialog surface uses [LemonadeTheme.radius.radius400] for rounded corners.
+ * - The dialog surface uses [LemonadeTheme.radius] `semantic.radiusContainerDefault` for rounded
+ *   corners.
  * - Background color is [LemonadeTheme.colors.background.bgDefault].
  * - Tonal elevation is set to 0.dp; the dialog relies on Lemonade color tokens for visual hierarchy.
  * - The dialog keeps whichever system bars the host window hides, never shows one the host hides.
@@ -109,7 +110,7 @@ public fun LemonadeUi.Dialog(
                 } else {
                     Modifier.fillMaxWidth()
                 },
-                shape = RoundedCornerShape(size = LemonadeTheme.radius.radius400),
+                shape = RoundedCornerShape(size = LemonadeTheme.radius.semantic.radiusContainerDefault),
                 color = LemonadeTheme.colors.background.bgDefault,
                 tonalElevation = 0.dp,
                 content = content,


### PR DESCRIPTION
# Summary
The Compose `Dialog` surface hardcoded `radius400` (16dp) for its corners, while every other Lemonade container reads `radius.semantic.radiusContainerDefault` (24dp). Dialogs therefore looked visibly squarer than cards and sheets. The surface now uses the semantic token, and the KDoc design note was updated to match.

## Figma component
<!-- Provide figma link (if any) to the component, it makes it easy for reviewers to find it -->

## Screenshot
| Before | After |
| ------ | ----- |
| <img width="300" src="https://github.com/user-attachments/assets/aaf0eeaa-315f-4711-aa1b-dce30cd4eb20" /> | <img width="300" src="https://github.com/user-attachments/assets/3b059a66-030b-4c92-8b90-db3e0b07ff73" /> |

## Comparison
<img width="600" src="https://github.com/user-attachments/assets/7eafd1ed-8670-488e-9dfa-99f2f24186f9" />

## API Dump
No public API changes.