### PR TITLE
fix(dialog): keep a minimum margin from the window edge

### DIFF
--- a/kmp/expressive/src/commonMain/kotlin/com/teya/lemonade/Dialog.kt
+++ b/kmp/expressive/src/commonMain/kotlin/com/teya/lemonade/Dialog.kt
@@ -75,9 +75,10 @@ import androidx.compose.ui.window.DialogProperties
  * - The dialog surface uses [LemonadeTheme.radius] `semantic.radiusContainerDefault` for rounded
  *   corners.
  * - Background color is [LemonadeTheme.colors.background.bgDefault].
- * - The dialog keeps at least `spacing600` (24.dp) between itself and each window edge. On a
- *   window narrower than roughly 328.dp the margin shrinks, because [BasicAlertDialog]'s own
- *   280.dp minimum width wins over it.
+ * - The dialog keeps `spacing600` (24.dp) between itself and each window edge wherever the window
+ *   is wide enough to allow it. Below roughly 328.dp of window it is not: [BasicAlertDialog]'s own
+ *   280.dp minimum width outranks the margin, and the dialog stays 280.dp wide with whatever is
+ *   left over as its margin.
  * - Tonal elevation is set to 0.dp; the dialog relies on Lemonade color tokens for visual hierarchy.
  * - The dialog keeps whichever system bars the host window hides, never shows one the host hides.
  * - For overlay components with a unified visibility API, see also [LemonadeUi.Dropdown] and

--- a/kmp/expressive/src/commonMain/kotlin/com/teya/lemonade/Dialog.kt
+++ b/kmp/expressive/src/commonMain/kotlin/com/teya/lemonade/Dialog.kt
@@ -3,12 +3,15 @@ package com.teya.lemonade
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.BasicAlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalWindowInfo
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.DialogProperties
 
@@ -37,6 +40,9 @@ import androidx.compose.ui.window.DialogProperties
  *   whatever this is set to. Anything narrower is padded out to 280.dp, and anything wider is
  *   clipped at 560.dp rather than growing, so content approaching that ceiling has little room
  *   left for a larger font scale or a longer translation.
+ *
+ *   A width that fits at the default display size is not proof it fits at the largest one: the
+ *   dialog is narrowed further to keep its margin from the window edge, per the Design Notes.
  *
  *   Sizing to the content means measuring its intrinsic width, which not every layout can answer:
  *   a `LazyColumn`, `LazyRow` or anything else built on `SubcomposeLayout` throws when asked. Keep
@@ -69,6 +75,9 @@ import androidx.compose.ui.window.DialogProperties
  * - The dialog surface uses [LemonadeTheme.radius] `semantic.radiusContainerDefault` for rounded
  *   corners.
  * - Background color is [LemonadeTheme.colors.background.bgDefault].
+ * - The dialog keeps at least `spacing600` (24.dp) between itself and each window edge. On a
+ *   window narrower than roughly 328.dp the margin shrinks, because [BasicAlertDialog]'s own
+ *   280.dp minimum width wins over it.
  * - Tonal elevation is set to 0.dp; the dialog relies on Lemonade color tokens for visual hierarchy.
  * - The dialog keeps whichever system bars the host window hides, never shows one the host hides.
  * - For overlay components with a unified visibility API, see also [LemonadeUi.Dropdown] and
@@ -91,6 +100,22 @@ public fun LemonadeUi.Dialog(
     val mirrorSystemBars = systemBarsMirror()
 
     if (expanded) {
+        // Android hands a platform-width dialog a fixed 320.dp regardless of how wide the window
+        // is, so on a 320.dp-wide window — a phone at the largest display size — the fill below
+        // would run edge to edge and clip the rounded corners.
+        //
+        // Read against the host window rather than from inside the dialog: a dialog provides its
+        // own LocalWindowInfo carrying the size it was measured at, so reading it there would ask
+        // how wide the window is while the window is still deciding how wide the dialog wants to
+        // be.
+        val windowWidth = LocalWindowInfo.current.containerDpSize.width
+        val maxWidth = if (windowWidth > 0.dp) {
+            windowWidth - LemonadeTheme.spaces.spacing600 * 2
+        } else {
+            // The window has not been measured yet; that frame goes without the cap.
+            Dp.Unspecified
+        }
+
         BasicAlertDialog(
             onDismissRequest = onDismissRequest,
             properties = DialogProperties(
@@ -105,11 +130,20 @@ public fun LemonadeUi.Dialog(
                 // measured at its widest child instead — filling here, or leaving the width
                 // unconstrained, would stretch it to the screen edges and the content would decide
                 // nothing. Callers keep filling the width they are given either way.
-                modifier = if (sizeToContent) {
-                    Modifier.width(intrinsicSize = IntrinsicSize.Max)
-                } else {
-                    Modifier.fillMaxWidth()
-                },
+                //
+                // The cap goes outside the fill so it narrows what the fill expands into. Padding
+                // would look the same but wouldn't behave the same: Compose decides a tap is
+                // outside the dialog from the composed content's own bounds, so a padded gap would
+                // read as part of the dialog and swallow the tap instead of dismissing.
+                modifier = Modifier
+                    .widthIn(max = maxWidth)
+                    .then(
+                        other = if (sizeToContent) {
+                            Modifier.width(intrinsicSize = IntrinsicSize.Max)
+                        } else {
+                            Modifier.fillMaxWidth()
+                        },
+                    ),
                 shape = RoundedCornerShape(size = LemonadeTheme.radius.semantic.radiusContainerDefault),
                 color = LemonadeTheme.colors.background.bgDefault,
                 tonalElevation = 0.dp,

--- a/kmp/expressive/src/commonMain/kotlin/com/teya/lemonade/TimePicker.kt
+++ b/kmp/expressive/src/commonMain/kotlin/com/teya/lemonade/TimePicker.kt
@@ -278,8 +278,9 @@ public fun LemonadeUi.TimeInput(
  * - On a short or wide window — a landscape phone or a tablet — Material lays the dial out
  *   side by side with the selected time, and the dialog takes the width that layout needs rather
  *   than the platform's default dialog width, which would clip the clock face. That side-by-side
- *   layout measures around 530.dp against [LemonadeUi.Dialog]'s 560.dp ceiling, so it is worth
- *   re-checking the dial on a large font scale before widening anything inside this dialog.
+ *   layout measures around 530.dp against the ceiling [LemonadeUi.Dialog] allows — 560.dp, and
+ *   less than that once its edge margin binds on a narrow window — so it is worth re-checking the
+ *   dial on a large font scale before widening anything inside this dialog.
  *
  * @param expanded Whether the dialog is currently visible. When `false`, nothing is composed.
  * @param title Heading shown above the picker, already localized.


### PR DESCRIPTION
# Summary

On Android, `LemonadeUi.Dialog` could run edge to edge with its rounded corners clipped. The platform hands a dialog a fixed 320.dp width whatever the window width is, and the surface filled it — so on a 320.dp-wide window (a phone at the largest display size) there was no margin left at all.

The dialog now keeps at least `spacing600` (24.dp) from each window edge.

Measured on a Pixel 10a:

| Screen width | Before | After |
| --- | --- | --- |
| 411.dp (default) | 320.dp, ~46.dp margin | unchanged |
| 360.dp | 320.dp, 20.dp margin | 312.dp, 24.dp margin |
| 320.dp (largest display size) | full width, corners clipped | 280.dp, 20.dp margin |

At 320.dp the margin lands at 20.dp rather than 24.dp: `BasicAlertDialog` propagates a 280.dp minimum width that outranks the cap, so below roughly a 328.dp window the margin gets whatever is left. That's documented in the KDoc.

## Figma component

n/a — no visual spec change, the dialog just stops touching the edge.

## Evidences
| Before | After |
| ------ | ----- |
| <img width="300" src="https://github.com/user-attachments/assets/91e53b63-e13d-47b5-ae32-16513d9f68dc" /> | <img width="300" src="https://github.com/user-attachments/assets/8f63d74e-c0d7-4316-bdda-4fe6560d59cd" /> |

## API Dump

No public API changes.

**Verdict:** NO_CHANGES

🤖 Generated with [Claude Code](https://claude.com/claude-code)
