### PR TITLE
fix(swiftui): fix unreliable top bar click with ToolbarIconButton

### DIFF
--- a/swiftui/SampleApp/HomeView.swift
+++ b/swiftui/SampleApp/HomeView.swift
@@ -166,12 +166,11 @@ struct HomeView: View {
         .disableAutocorrection(true)
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
-                Button(action: { showSettings = true }) {
-                    LemonadeUi.Icon(
-                        icon: .gear,
-                        contentDescription: "Settings"
-                    )
-                }
+                LemonadeUi.ToolbarIconButton(
+                    icon: .gear,
+                    contentDescription: "Settings",
+                    action: { showSettings = true }
+                )
             }
         }
         .sheet(isPresented: $showSettings) {

--- a/swiftui/SampleApp/SettingsView.swift
+++ b/swiftui/SampleApp/SettingsView.swift
@@ -32,12 +32,11 @@ struct SettingsView: View {
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {
-                    Button(action: { dismiss() }) {
-                        LemonadeUi.Icon(
-                            icon: .times,
-                            contentDescription: "Close"
-                        )
-                    }
+                    LemonadeUi.ToolbarIconButton(
+                        icon: .times,
+                        contentDescription: "Close",
+                        action: { dismiss() }
+                    )
                 }
             }
         }

--- a/swiftui/SampleApp/TopBarDisplayView.swift
+++ b/swiftui/SampleApp/TopBarDisplayView.swift
@@ -152,9 +152,11 @@ private struct BasicTrailingSlotDemo: View {
             navigationAction: NavigationAction(action: .back, onAction: {})
         ) {
             ToolbarItem(placement: .navigationBarTrailing) {
-                Button(action: {}) {
-                    LemonadeUi.Icon(icon: .bell, contentDescription: "Notifications")
-                }
+                LemonadeUi.ToolbarIconButton(
+                    icon: .bell,
+                    contentDescription: "Notifications",
+                    action: {}
+                )
             }
             #if compiler(>=6.2)
             if #available(iOS 26, *) {
@@ -162,9 +164,11 @@ private struct BasicTrailingSlotDemo: View {
             }
             #endif
             ToolbarItem(placement: .navigationBarTrailing) {
-                Button(action: {}) {
-                    LemonadeUi.Icon(icon: .ellipsisHorizontal, contentDescription: "More")
-                }
+                LemonadeUi.ToolbarIconButton(
+                    icon: .ellipsisHorizontal,
+                    contentDescription: "More",
+                    action: {}
+                )
             }
         }
     }
@@ -209,9 +213,11 @@ private struct BasicSubheadingDemo: View {
             navigationAction: NavigationAction(action: .back, onAction: {})
         ) {
             ToolbarItem(placement: .navigationBarTrailing) {
-                Button(action: {}) {
-                    LemonadeUi.Icon(icon: .bell, contentDescription: "Notifications")
-                }
+                LemonadeUi.ToolbarIconButton(
+                    icon: .bell,
+                    contentDescription: "Notifications",
+                    action: {}
+                )
             }
         }
     }
@@ -280,9 +286,11 @@ private struct SearchExpandedLabelDemo: View {
             navigationAction: NavigationAction(action: .back, onAction: {})
         ) {
             ToolbarItem(placement: .navigationBarTrailing) {
-                Button(action: {}) {
-                    LemonadeUi.Icon(icon: .filter, contentDescription: "Filter")
-                }
+                LemonadeUi.ToolbarIconButton(
+                    icon: .filter,
+                    contentDescription: "Filter",
+                    action: {}
+                )
             }
         }
     }
@@ -359,14 +367,11 @@ private struct CompactLargeCloseButton: ToolbarContent {
 
     var body: some ToolbarContent {
         ToolbarItem(placement: .topBarTrailing) {
-            Button(action: { dismiss() }) {
-                LemonadeUi.Icon(icon: .times, contentDescription: "Close")
-                    .frame(
-                        minWidth: LemonadeSizes.size800.value,
-                        minHeight: LemonadeSizes.size800.value
-                    )
-                    .contentShape(Rectangle())
-            }
+            LemonadeUi.ToolbarIconButton(
+                icon: .times,
+                contentDescription: "Close",
+                action: { dismiss() }
+            )
         }
     }
 }
@@ -380,12 +385,16 @@ private struct CompactLargePillDemo: View {
         }
         .lemonadeTopBar(label: "Home", subheading: "Pill trailing") {
             ToolbarItemGroup(placement: .topBarTrailing) {
-                Button(action: {}) {
-                    LemonadeUi.Icon(icon: .bell, contentDescription: "Notifications")
-                }
-                Button(action: {}) {
-                    LemonadeUi.Icon(icon: .gear, contentDescription: "Settings")
-                }
+                LemonadeUi.ToolbarIconButton(
+                    icon: .bell,
+                    contentDescription: "Notifications",
+                    action: {}
+                )
+                LemonadeUi.ToolbarIconButton(
+                    icon: .gear,
+                    contentDescription: "Settings",
+                    action: {}
+                )
             }
             CompactLargeCloseButton(dismiss: dismiss)
         }
@@ -401,14 +410,18 @@ private struct CompactLargeDemo: View {
         }
         .lemonadeTopBar(label: "Home", subheading: nil) {
             ToolbarItem(placement: .topBarTrailing) {
-                Button(action: {}) {
-                    LemonadeUi.Icon(icon: .bell, contentDescription: "Notifications")
-                }
+                LemonadeUi.ToolbarIconButton(
+                    icon: .bell,
+                    contentDescription: "Notifications",
+                    action: {}
+                )
             }
             ToolbarItem(placement: .topBarTrailing) {
-                Button(action: {}) {
-                    LemonadeUi.Icon(icon: .gear, contentDescription: "Settings")
-                }
+                LemonadeUi.ToolbarIconButton(
+                    icon: .gear,
+                    contentDescription: "Settings",
+                    action: {}
+                )
             }
             CompactLargeCloseButton(dismiss: dismiss)
         }
@@ -424,9 +437,11 @@ private struct CompactLargeSubheadingDemo: View {
         }
         .lemonadeTopBar(label: "Home", subheading: "Welcome back, John") {
             ToolbarItem(placement: .topBarTrailing) {
-                Button(action: {}) {
-                    LemonadeUi.Icon(icon: .bell, contentDescription: "Notifications")
-                }
+                LemonadeUi.ToolbarIconButton(
+                    icon: .bell,
+                    contentDescription: "Notifications",
+                    action: {}
+                )
             }
             CompactLargeCloseButton(dismiss: dismiss)
         }
@@ -481,9 +496,11 @@ private struct CompactLargeSearchDemo: View {
             searchPrompt: "Search categories..."
         ) {
             ToolbarItem(placement: .topBarTrailing) {
-                Button(action: {}) {
-                    LemonadeUi.Icon(icon: .ellipsisHorizontal, contentDescription: "More")
-                }
+                LemonadeUi.ToolbarIconButton(
+                    icon: .ellipsisHorizontal,
+                    contentDescription: "More",
+                    action: {}
+                )
             }
             CompactLargeCloseButton(dismiss: dismiss)
         }

--- a/swiftui/Sources/Lemonade/Components/LemonadeToolbarIconButton.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeToolbarIconButton.swift
@@ -1,0 +1,159 @@
+import SwiftUI
+
+// MARK: - Toolbar Icon Prominence
+
+/// Fill treatment for a navigation bar's icon button.
+public enum LemonadeToolbarIconProminence {
+    /// The bar draws its own chrome. Correct for almost every action.
+    case plain
+    /// Filled with `tint` — for the single primary action in a bar, if any.
+    case filled(tint: Color)
+}
+
+// MARK: - Toolbar Icon Button
+
+public extension LemonadeUi {
+    /// An icon button for a navigation bar's `ToolbarItem`.
+    ///
+    /// Use this rather than a hand-rolled `Button`, and never put a ``LemonadeUi/IconButton`` in a
+    /// toolbar: that is a control inside the bar's own control, and it renders as a pill.
+    ///
+    /// ## Why this exists
+    ///
+    /// SwiftUI turns a `ToolbarItem` into a real `UIBarButtonItem` only when it recognises the
+    /// button's label. Anything else is wrapped in a `UIKitBarItemHost`, which UIKit caps at 36x36
+    /// with only a 24x36 interactive view inside it — so roughly 6pt of each edge is dead while the
+    /// control still looks like a full circle. Measured on an iPhone:
+    ///
+    /// ```
+    /// plain image label            UIKitBarItemHost    {{337, 63}, {36, 36}}
+    ///   live area within           _UIScrollPocket     {{343, 63}, {24, 36}}
+    /// wrapped in a Label           _UIButtonBarButton  {{337, 63}, {36, 36}}
+    /// ```
+    ///
+    /// A `Label` is the only shape that bridges. An `Image` does not, not even a bare
+    /// `Image(systemName:)` with no modifiers — measured, so do not reach for one. Nor does
+    /// anything applied to the label help: a larger `.frame`, a `.contentShape` and a button style
+    /// were each measured and left the interactive view at 24pt, because UIKit clips hit-testing to
+    /// the bar item's bounds.
+    ///
+    /// The `Label` is not a trick. A `UIBarButtonItem` genuinely is a title plus an image;
+    /// `.iconOnly` hides the title visually and leaves it to assistive technology.
+    ///
+    /// - Parameters:
+    ///   - icon: The icon to display.
+    ///   - contentDescription: Describes the action. Becomes the accessibility label.
+    ///   - prominence: Fill treatment. Defaults to `.plain`.
+    ///   - action: Invoked on tap.
+    @ViewBuilder
+    static func ToolbarIconButton(
+        icon: LemonadeIcon,
+        contentDescription: String,
+        prominence: LemonadeToolbarIconProminence = .plain,
+        action: @escaping () -> Void
+    ) -> some View {
+        LemonadeToolbarIconButtonView(
+            icon: icon,
+            contentDescription: contentDescription,
+            prominence: prominence,
+            action: action
+        )
+    }
+
+    /// The menu counterpart of ``LemonadeUi/ToolbarIconButton(icon:contentDescription:prominence:action:)``,
+    /// for a bar item that opens a menu rather than firing an action.
+    @ViewBuilder
+    static func ToolbarIconMenu<Content: View>(
+        icon: LemonadeIcon,
+        contentDescription: String,
+        prominence: LemonadeToolbarIconProminence = .plain,
+        @ViewBuilder content: @escaping () -> Content
+    ) -> some View {
+        LemonadeToolbarIconMenuView(
+            icon: icon,
+            contentDescription: contentDescription,
+            prominence: prominence,
+            content: content
+        )
+    }
+}
+
+// MARK: - Internal Views
+
+private struct LemonadeToolbarIconButtonView: View {
+    let icon: LemonadeIcon
+    let contentDescription: String
+    let prominence: LemonadeToolbarIconProminence
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            LemonadeToolbarIconLabel(icon: icon, title: contentDescription)
+        }
+        .lemonadeToolbarProminence(prominence)
+    }
+}
+
+private struct LemonadeToolbarIconMenuView<Content: View>: View {
+    let icon: LemonadeIcon
+    let contentDescription: String
+    let prominence: LemonadeToolbarIconProminence
+    @ViewBuilder let content: () -> Content
+
+    var body: some View {
+        menu.lemonadeToolbarProminence(prominence)
+    }
+
+    @ViewBuilder
+    private var menu: some View {
+        if #available(iOS 16.0, *) {
+            rawMenu
+                // Without this a `Menu` ignores `.buttonStyle` entirely, so a prominent tint lands
+                // on the glyph instead of filling the button.
+                .menuStyle(.button)
+        } else {
+            rawMenu
+        }
+    }
+
+    private var rawMenu: some View {
+        Menu {
+            // A prominent tint is an environment value, so it reaches the menu's own rows and
+            // recolours their glyphs. Reset it for the content.
+            content()
+                .tint(LemonadeTheme.colors.content.contentPrimary)
+        } label: {
+            LemonadeToolbarIconLabel(icon: icon, title: contentDescription)
+        }
+    }
+}
+
+/// The label shape a bar button needs. Shared by the button and the menu so both spell it the same
+/// way, and so the reason survives someone refactoring one of them.
+private struct LemonadeToolbarIconLabel: View {
+    let icon: LemonadeIcon
+    let title: String
+
+    var body: some View {
+        Label {
+            Text(title)
+        } icon: {
+            LemonadeUi.Icon(icon: icon, contentDescription: nil, size: .medium)
+        }
+        .labelStyle(.iconOnly)
+    }
+}
+
+private extension View {
+    @ViewBuilder
+    func lemonadeToolbarProminence(_ prominence: LemonadeToolbarIconProminence) -> some View {
+        switch prominence {
+        case .plain:
+            self
+        case let .filled(tint):
+            // `.borderedProminent`, not `.glassProminent`: a `Menu` loses the glass-prominent style
+            // across the bar-item bridge, and its tint then colours the glyph rather than the fill.
+            self.buttonStyle(.borderedProminent).tint(tint)
+        }
+    }
+}

--- a/swiftui/Sources/Lemonade/Modifiers/LemonadeTopBar.swift
+++ b/swiftui/Sources/Lemonade/Modifiers/LemonadeTopBar.swift
@@ -62,13 +62,11 @@ private struct BasicTopBarModifier<Toolbar: ToolbarContent, BottomContent: View>
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
                     if let navigationAction, navigationAction.action == .close {
-                        Button(action: navigationAction.onAction) {
-                            LemonadeUi.Icon(
-                                icon: .times,
-                                contentDescription: "Close"
-                            )
-                            .clickableFrame(minSize: .size800)
-                        }
+                        LemonadeUi.ToolbarIconButton(
+                            icon: .times,
+                            contentDescription: "Close",
+                            action: navigationAction.onAction
+                        )
                     }
                 }
                 toolbarContent
@@ -104,13 +102,11 @@ private struct SearchTopBarModifier<Toolbar: ToolbarContent, BottomContent: View
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
                     if let navigationAction, navigationAction.action == .close {
-                        Button(action: navigationAction.onAction) {
-                            LemonadeUi.Icon(
-                                icon: .times,
-                                contentDescription: "Close"
-                            )
-                            .clickableFrame(minSize: .size800)
-                        }
+                        LemonadeUi.ToolbarIconButton(
+                            icon: .times,
+                            contentDescription: "Close",
+                            action: navigationAction.onAction
+                        )
                     }
                 }
                 toolbarContent


### PR DESCRIPTION
# Summary
Clicking the edge of an ios Button with a lemonade icon did not respond, including in lemonade's topbar due to a weird interaction between swift ui and uikit, see claude's explanation below.

An icon-only button in a `ToolbarItem` responds only across the middle of its circle. SwiftUI hosts a bar item whose content it cannot recognise in a `UIKitBarItemHost`, capped at 36x36 with a 24x36 interactive view inside it, so roughly 6pt of each edge is dead while the control still looks like a comfortable target. Measured on an iPhone by dumping the nav bar's view tree:

  bare icon label     UIKitBarItemHost    {{337, 63}, {36, 36}}
    live area within  _UIScrollPocket     {{343, 63}, {24, 36}}
  wrapped in a Label  _UIButtonBarButton  {{337, 63}, {36, 36}}

Nothing applied to the label moves those numbers — a larger `.frame`, a `.contentShape`, and a button style were each measured and left the interactive view at 24pt, because UIKit clips hit-testing to the bar item's bounds. What does change it is the label's shape: wrapped in a `Label`, SwiftUI hands UIKit a real `_UIButtonBarButton`, which hit-tests its whole frame. `.iconOnly` means this renders exactly as the bare image everywhere else.

`lemonadeTopBar`'s own close buttons also drop `clickableFrame(minSize: .size800)`. At 32pt it is under the 36pt cap so it never grew anything, and applying it to the label is itself part of what forces the hosted path.

## Figma component
<!-- Provide figma link (if any) to the component, it makes it easy for reviewers to find it -->

## Screenshot
<!-- Provide at least one image of your change if applicable -->
<!-- <img src="drawing.jpg" alt="drawing" width="200"/> -->
<!-- You can define the width/height to resize the image if needed -->

## API Dump
<!--
Required when any kmp/<module>/api/*.api or *.klib.api file changed.
Run `.claude/skills/binary-compatibility/scripts/bcv-check.sh --ci` to get the verdict.
If nothing in api/ changed, write "No public API changes" and delete the rest.
-->

**Verdict:** <!-- NO_CHANGES / ADDITIONS_ONLY / BREAKING -->

**Changes that are not a concern, and why:**
<!--
- Interface addition — the interface is local-only, no external implementers.
- Enum entry addition — config enum; the component owns the `when`.
- `@Deprecated(HIDDEN)` overload — the `-` line is only the `synthetic` flag,
  the JVM descriptor is unchanged, so already-compiled consumers keep linking.
-->

**Genuine breaking changes (if any):**
<!--
List each one, who needs to approve (@caiqueslp / @williankl / @DevSrSouza),
and why the break is acceptable. Leave empty if the verdict is not BREAKING.
-->
