### PR TITLE
fix(button): align button spacing and icon-button glyphs with Figma

### DIFF
--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Button.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Button.kt
@@ -106,7 +106,7 @@ public fun LemonadeUi.Button(
                     textAlign = TextAlign.Center,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier.padding(horizontal = LocalSpaces.current.spacing200),
+                    modifier = Modifier.padding(horizontal = size.contentData.labelPadding),
                 )
 
                 if (trailingIcon != null) {
@@ -182,7 +182,7 @@ public fun LemonadeUi.Button(
                     textAlign = TextAlign.Center,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier.padding(horizontal = LocalSpaces.current.spacing200),
+                    modifier = Modifier.padding(horizontal = size.contentData.labelPadding),
                 )
             }
         },
@@ -200,6 +200,7 @@ public class LemonadeButtonColors internal constructor(
 private data class LemonadeButtonContentData(
     val verticalPadding: Dp,
     val horizontalPadding: Dp,
+    val labelPadding: Dp,
     val requiredHeight: Dp,
     val minWidth: Dp,
     val shape: Shape,
@@ -212,6 +213,7 @@ private val LemonadeButtonSize.contentData: LemonadeButtonContentData
             LemonadeButtonSize.XSmall -> LemonadeButtonContentData(
                 verticalPadding = LocalSpaces.current.spacing100,
                 horizontalPadding = LocalSpaces.current.spacing200,
+                labelPadding = LocalSpaces.current.spacing100,
                 requiredHeight = LocalSizes.current.size800,
                 minWidth = LocalSizes.current.size1600,
                 shape = LocalShapes.current.radius250,
@@ -221,6 +223,7 @@ private val LemonadeButtonSize.contentData: LemonadeButtonContentData
             LemonadeButtonSize.Small -> LemonadeButtonContentData(
                 verticalPadding = LocalSpaces.current.spacing200,
                 horizontalPadding = LocalSpaces.current.spacing300,
+                labelPadding = LocalSpaces.current.spacing200,
                 requiredHeight = LocalSizes.current.size1000,
                 minWidth = LocalSizes.current.size1600,
                 shape = LocalShapes.current.radius300,
@@ -230,6 +233,7 @@ private val LemonadeButtonSize.contentData: LemonadeButtonContentData
             LemonadeButtonSize.Medium -> LemonadeButtonContentData(
                 verticalPadding = LocalSpaces.current.spacing300,
                 horizontalPadding = LocalSpaces.current.spacing400,
+                labelPadding = LocalSpaces.current.spacing200,
                 requiredHeight = LocalSizes.current.size1200,
                 minWidth = LocalSizes.current.size1600,
                 shape = LocalShapes.current.radius350,
@@ -239,6 +243,7 @@ private val LemonadeButtonSize.contentData: LemonadeButtonContentData
             LemonadeButtonSize.Large -> LemonadeButtonContentData(
                 verticalPadding = LocalSpaces.current.spacing300,
                 horizontalPadding = LocalSpaces.current.spacing400,
+                labelPadding = LocalSpaces.current.spacing200,
                 requiredHeight = LocalSizes.current.size1400,
                 minWidth = LocalSizes.current.size1600,
                 shape = LocalShapes.current.radius400,

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/IconButton.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/IconButton.kt
@@ -345,7 +345,7 @@ private fun LemonadeButtonSize.toSizeData(shape: LemonadeIconButtonShape): IconB
         )
 
         LemonadeButtonSize.Medium -> IconButtonSizeData(
-            iconSize = LemonadeAssetSize.Large,
+            iconSize = LemonadeAssetSize.Medium,
             spinnerSize = LemonadeAssetSize.Small,
             size = LocalSizes.current.size1200,
             shape = shape.resolveShape(roundedShape = LocalShapes.current.radius350),

--- a/swiftui/Sources/Lemonade/Components/LemonadeButton.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeButton.swift
@@ -205,6 +205,7 @@ public struct LemonadeButtonColors {
 private struct LemonadeButtonContentData {
     let verticalPadding: CGFloat
     let horizontalPadding: CGFloat
+    let labelPadding: CGFloat
     let requiredHeight: CGFloat
     let minWidth: CGFloat
     let cornerRadius: CGFloat
@@ -220,6 +221,7 @@ private extension LemonadeButtonSize {
             return LemonadeButtonContentData(
                 verticalPadding: LemonadeTheme.spaces.spacing100,
                 horizontalPadding: LemonadeTheme.spaces.spacing200,
+                labelPadding: LemonadeTheme.spaces.spacing100,
                 requiredHeight: LemonadeTheme.sizes.size800,
                 minWidth: LemonadeTheme.sizes.size1600,
                 cornerRadius: LemonadeTheme.radius.radius250,
@@ -229,6 +231,7 @@ private extension LemonadeButtonSize {
             return LemonadeButtonContentData(
                 verticalPadding: LemonadeTheme.spaces.spacing200,
                 horizontalPadding: LemonadeTheme.spaces.spacing300,
+                labelPadding: LemonadeTheme.spaces.spacing200,
                 requiredHeight: LemonadeTheme.sizes.size1000,
                 minWidth: LemonadeTheme.sizes.size1600,
                 cornerRadius: LemonadeTheme.radius.radius300,
@@ -238,6 +241,7 @@ private extension LemonadeButtonSize {
             return LemonadeButtonContentData(
                 verticalPadding: LemonadeTheme.spaces.spacing300,
                 horizontalPadding: LemonadeTheme.spaces.spacing400,
+                labelPadding: LemonadeTheme.spaces.spacing200,
                 requiredHeight: LemonadeTheme.sizes.size1200,
                 minWidth: LemonadeTheme.sizes.size1600,
                 cornerRadius: LemonadeTheme.radius.radius350,
@@ -247,6 +251,7 @@ private extension LemonadeButtonSize {
             return LemonadeButtonContentData(
                 verticalPadding: LemonadeTheme.spaces.spacing300,
                 horizontalPadding: LemonadeTheme.spaces.spacing400,
+                labelPadding: LemonadeTheme.spaces.spacing200,
                 requiredHeight: LemonadeTheme.sizes.size1400,
                 minWidth: LemonadeTheme.sizes.size1600,
                 cornerRadius: LemonadeTheme.radius.radius400,
@@ -503,7 +508,7 @@ private struct LemonadeButtonView: View {
                         maxLines: 1
                     )
                     .multilineTextAlignment(.center)
-                    .padding(.horizontal, LemonadeTheme.spaces.spacing200)
+                    .padding(.horizontal, size.contentData.labelPadding)
 
                     if let trailingIcon = trailingIcon {
                         LemonadeUi.Icon(
@@ -554,7 +559,7 @@ private struct LemonadeSlotButtonView<LeadingSlot: View, TrailingSlot: View>: Vi
                         maxLines: 1
                     )
                     .multilineTextAlignment(.center)
-                    .padding(.horizontal, LemonadeTheme.spaces.spacing200)
+                    .padding(.horizontal, size.contentData.labelPadding)
                 )
             },
             leadingSlot: leadingSlot,

--- a/swiftui/Sources/Lemonade/Components/LemonadeIconButton.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeIconButton.swift
@@ -114,13 +114,13 @@ private extension LemonadeButtonSize {
             )
         case .medium:
             return LemonadeIconButtonSizeData(
-                iconSize: .large,
+                iconSize: .medium,
                 size: LemonadeTheme.sizes.size1200,
                 cornerRadius: LemonadeTheme.radius.radius350
             )
         case .small:
             return LemonadeIconButtonSizeData(
-                iconSize: .small,
+                iconSize: .medium,
                 size: LemonadeTheme.sizes.size1000,
                 cornerRadius: LemonadeTheme.radius.radius300
             )


### PR DESCRIPTION
## Summary

Audited every button size in code against the Figma component sets — **Button** (node `8302:10112`) and **Icon Button** (node `17383:2038`) — reading each size variant's geometry and variable bindings. Heights, radii, paddings, and text styles all match token-for-token on KMP and SwiftUI; three deviations were found and are fixed here:

- **XSmall label inner padding** — Figma binds `spacing-100` (4dp) for XSmall, `spacing-200` (8dp) for the other sizes; code used a flat 8dp everywhere. `LemonadeButtonContentData` now carries a per-size `labelPadding` on both platforms.
- **IconButton Medium glyph** — Figma pairs the 48dp box with a 20dp glyph; both platforms rendered 24dp. Note: Medium is the IconButton default size, so the glyph visibly shrinks wherever it's used.
- **IconButton Small glyph (SwiftUI only)** — was 16dp; Figma and KMP use 20dp (KMP was aligned in #297, which never got its SwiftUI twin).

Documented but intentionally not changed: the 64dp min-width on labeled buttons (tap-target floor; Figma is hug-width), code's XSmall IconButton (no Figma counterpart), and the Flutter button drift (xSmall height 40 vs 32, medium radius 12 vs 14, xSmall radius 8 vs 10) — left for a separate pass.

## Before / after (Android emulator)

Captured from `:composeApp` debug builds of the base commit vs this branch on a Pixel 7 AVD (API 36), same navigation sequence. The pixel diff between builds is confined to the expected regions: the Button sizes row (XSmall tightens by 4dp per side) and the Medium icon-button glyph column (48→40px on-screen, exactly the 24→20dp ratio).

**Button — XSmall label padding** (XSmall narrows, other sizes shift left):

![Button before/after](https://raw.githubusercontent.com/teya-engineering/lemonade-design-system/pr-369-assets/pr_button_before_after.png)

**IconButton — Medium glyph 24→20** (box sizes unchanged):

![IconButton before/after](https://raw.githubusercontent.com/teya-engineering/lemonade-design-system/pr-369-assets/pr_iconbutton_before_after.png)

The SwiftUI-only Small glyph fix is not visible in these Android captures.

*Screenshots are hosted on the `pr-369-assets` branch — delete it after merge.*

## API Dump

No public API changes. `bcv-check.sh --ci` verdict: `NO_CHANGES` — all touched declarations (`LemonadeButtonContentData`, `IconButtonSizeData`, and their SwiftUI twins) are private.

https://claude.ai/code/session_019tgToF9ENn3TNJ91Vy3WBQ