### PR TITLE
fix(swipe-action-row): hand back a drag claim a context menu took

### DIFF
--- a/swiftui/SampleApp/SwipeActionRowDisplayView.swift
+++ b/swiftui/SampleApp/SwipeActionRowDisplayView.swift
@@ -314,49 +314,7 @@ struct SwipeActionRowDisplayView: View {
                         }
                     }
 
-                    // Both affordances on one row: the swipe and the hold. A press drifts far
-                    // enough to claim the drag on its way to the menu, and the row has to give
-                    // that claim back rather than sit offset behind the menu until it goes.
-                    LemonadeUi.Card(
-                        header: CardHeaderConfig(
-                            title: "Swipe or hold",
-                            subtitle: "The row carries a context menu. Holding it leaves it where it is."
-                        )
-                    ) {
-                        LemonadeUi.SwipeActionRow(
-                            actions: [
-                                LemonadeSwipeAction(icon: .trash, contentDescription: "Delete", onClick: { })
-                            ],
-                            allowsFullSwipe: false
-                        ) {
-                            LemonadeUi.ActionListItem(
-                                label: "Swipe or hold",
-                                supportText: "Both reach Delete",
-                                showDivider: false,
-                                onItemClicked: { }
-                            )
-                        }
-                        // Around the row rather than inside it. The lift a context menu does is a
-                        // snapshot of the view it is attached to, and a list item's own fill is
-                        // clear — so something has to give the snapshot a surface. Putting that
-                        // surface in the content would bury the row's own press tint, which is
-                        // translucent and drawn behind whatever the content is: the row would
-                        // stop filling in under a swipe, alone among the rows on this screen.
-                        .background(
-                            RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius500)
-                                .fill(LemonadeTheme.colors.background.bgDefault)
-                        )
-                        // The fill alone is not enough: the preview is otherwise clipped to iOS's
-                        // own corner radius, so the lift starts on one shape and settles on
-                        // another, and the row flickers as it goes.
-                        .contentShape(
-                            .contextMenuPreview,
-                            RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius500)
-                        )
-                        .contextMenu {
-                            Button("Delete", role: .destructive) { }
-                        }
-                    }
+                    swipeOrHoldCard
 
                     LemonadeUi.Card(
                         header: CardHeaderConfig(
@@ -408,6 +366,55 @@ struct SwipeActionRowDisplayView: View {
             // Plain rather than `.cancel`: iOS leaves a cancel-role button out of this
             // presentation, where tapping away is the way out.
             Button("Cancel") { pendingRemoval = nil }
+        }
+    }
+
+    /// Both affordances on one row: the swipe and the hold. A press drifts far enough to claim the
+    /// drag on its way to the menu, and the row has to give that claim back rather than sit offset
+    /// behind the menu until it goes.
+    ///
+    /// Held apart from `body` rather than written inline with the other cards: the screen is one
+    /// expression, and one card more is further than the type checker will follow.
+    private var swipeOrHoldCard: some View {
+        LemonadeUi.Card(
+            header: CardHeaderConfig(
+                title: "Swipe or hold",
+                subtitle: "The row carries a context menu. Holding it leaves it where it is."
+            )
+        ) {
+            LemonadeUi.SwipeActionRow(
+                trailingActions: [
+                    LemonadeSwipeAction(icon: .trash, contentDescription: "Delete", onClick: { })
+                ],
+                allowsFullSwipe: false
+            ) {
+                LemonadeUi.ActionListItem(
+                    label: "Swipe or hold",
+                    supportText: "Both reach Delete",
+                    showDivider: false,
+                    onItemClicked: { }
+                )
+            }
+            // Around the row rather than inside it. The lift a context menu does is a
+            // snapshot of the view it is attached to, and a list item's own fill is
+            // clear — so something has to give the snapshot a surface. Putting that
+            // surface in the content would bury the row's own press tint, which is
+            // translucent and drawn behind whatever the content is: the row would
+            // stop filling in under a swipe, alone among the rows on this screen.
+            .background(
+                RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius500)
+                    .fill(LemonadeTheme.colors.background.bgDefault)
+            )
+            // The fill alone is not enough: the preview is otherwise clipped to iOS's
+            // own corner radius, so the lift starts on one shape and settles on
+            // another, and the row flickers as it goes.
+            .contentShape(
+                .contextMenuPreview,
+                RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius500)
+            )
+            .contextMenu {
+                Button("Delete", role: .destructive) { }
+            }
         }
     }
 }

--- a/swiftui/SampleApp/SwipeActionRowDisplayView.swift
+++ b/swiftui/SampleApp/SwipeActionRowDisplayView.swift
@@ -338,12 +338,18 @@ struct SwipeActionRowDisplayView: View {
                             // The lift a context menu does is a snapshot of the view it is
                             // attached to, and a list item's own fill is clear — the Card behind
                             // it is the surface. Without one of its own the row lifts as floating
-                            // text, so this gives it the fill and the shape the row already wears
-                            // under a finger.
+                            // text.
                             .background(
                                 RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius500)
                                     .fill(LemonadeTheme.colors.background.bgDefault)
-                                    .padding(LemonadeTheme.spaces.spacing100)
+                            )
+                            // The fill alone is not enough: the preview is clipped to iOS's own
+                            // corner radius, so the lift starts on one shape and settles on
+                            // another, and the row flickers as it goes. Both have to be the same
+                            // rounded rectangle for it to lift cleanly.
+                            .contentShape(
+                                .contextMenuPreview,
+                                RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius500)
                             )
                             .contextMenu {
                                 Button("Delete", role: .destructive) { }

--- a/swiftui/SampleApp/SwipeActionRowDisplayView.swift
+++ b/swiftui/SampleApp/SwipeActionRowDisplayView.swift
@@ -320,7 +320,7 @@ struct SwipeActionRowDisplayView: View {
                     LemonadeUi.Card(
                         header: CardHeaderConfig(
                             title: "Swipe or hold",
-                            subtitle: "The content carries a context menu. Holding the row leaves it where it is."
+                            subtitle: "The row carries a context menu. Holding it leaves it where it is."
                         )
                     ) {
                         LemonadeUi.SwipeActionRow(
@@ -335,25 +335,26 @@ struct SwipeActionRowDisplayView: View {
                                 showDivider: false,
                                 onItemClicked: { }
                             )
-                            // The lift a context menu does is a snapshot of the view it is
-                            // attached to, and a list item's own fill is clear — the Card behind
-                            // it is the surface. Without one of its own the row lifts as floating
-                            // text.
-                            .background(
-                                RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius500)
-                                    .fill(LemonadeTheme.colors.background.bgDefault)
-                            )
-                            // The fill alone is not enough: the preview is clipped to iOS's own
-                            // corner radius, so the lift starts on one shape and settles on
-                            // another, and the row flickers as it goes. Both have to be the same
-                            // rounded rectangle for it to lift cleanly.
-                            .contentShape(
-                                .contextMenuPreview,
-                                RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius500)
-                            )
-                            .contextMenu {
-                                Button("Delete", role: .destructive) { }
-                            }
+                        }
+                        // Around the row rather than inside it. The lift a context menu does is a
+                        // snapshot of the view it is attached to, and a list item's own fill is
+                        // clear — so something has to give the snapshot a surface. Putting that
+                        // surface in the content would bury the row's own press tint, which is
+                        // translucent and drawn behind whatever the content is: the row would
+                        // stop filling in under a swipe, alone among the rows on this screen.
+                        .background(
+                            RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius500)
+                                .fill(LemonadeTheme.colors.background.bgDefault)
+                        )
+                        // The fill alone is not enough: the preview is otherwise clipped to iOS's
+                        // own corner radius, so the lift starts on one shape and settles on
+                        // another, and the row flickers as it goes.
+                        .contentShape(
+                            .contextMenuPreview,
+                            RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius500)
+                        )
+                        .contextMenu {
+                            Button("Delete", role: .destructive) { }
                         }
                     }
 

--- a/swiftui/SampleApp/SwipeActionRowDisplayView.swift
+++ b/swiftui/SampleApp/SwipeActionRowDisplayView.swift
@@ -314,6 +314,43 @@ struct SwipeActionRowDisplayView: View {
                         }
                     }
 
+                    // Both affordances on one row: the swipe and the hold. A press drifts far
+                    // enough to claim the drag on its way to the menu, and the row has to give
+                    // that claim back rather than sit offset behind the menu until it goes.
+                    LemonadeUi.Card(
+                        header: CardHeaderConfig(
+                            title: "Swipe or hold",
+                            subtitle: "The content carries a context menu. Holding the row leaves it where it is."
+                        )
+                    ) {
+                        LemonadeUi.SwipeActionRow(
+                            actions: [
+                                LemonadeSwipeAction(icon: .trash, contentDescription: "Delete", onClick: { })
+                            ],
+                            allowsFullSwipe: false
+                        ) {
+                            LemonadeUi.ActionListItem(
+                                label: "Swipe or hold",
+                                supportText: "Both reach Delete",
+                                showDivider: false,
+                                onItemClicked: { }
+                            )
+                            // The lift a context menu does is a snapshot of the view it is
+                            // attached to, and a list item's own fill is clear — the Card behind
+                            // it is the surface. Without one of its own the row lifts as floating
+                            // text, so this gives it the fill and the shape the row already wears
+                            // under a finger.
+                            .background(
+                                RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius500)
+                                    .fill(LemonadeTheme.colors.background.bgDefault)
+                                    .padding(LemonadeTheme.spaces.spacing100)
+                            )
+                            .contextMenu {
+                                Button("Delete", role: .destructive) { }
+                            }
+                        }
+                    }
+
                     LemonadeUi.Card(
                         header: CardHeaderConfig(
                             title: "enabled: false",

--- a/swiftui/Sources/Lemonade/Components/LemonadeSwipeActionRow.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeSwipeActionRow.swift
@@ -179,13 +179,17 @@ private let holdTravel: CGFloat = 24
 /// to claim the drag, and the menu then takes the touch — so the drag never ends, and the claim
 /// would otherwise sit on the row until the menu is dismissed.
 ///
-/// The measure is what the drag has asked for, not how long it has been asking: a row carried no
-/// further than the distance it travelled to claim the touch is showing nothing the reader can act
-/// on — the first action is not drawn at all until much further out — and a finger still on the row
-/// claims again on its next move, from where the row is being drawn. A reveal a reader is holding
-/// open to look at is well past this, and stays.
-func swipeHoldReleasesClaim(travelSinceClaim: CGFloat) -> Bool {
-    abs(travelSinceClaim) < holdTravel
+/// Only a closed row hands a claim back, and only one the claim has taken nowhere. A press cannot
+/// be told apart from a finger that has simply paused, so the row gives up a claim only where
+/// being wrong about that costs nothing: under `holdTravel` on a closed row nothing of the first
+/// action is drawn, and a finger still on the row claims again on its next move, from where the
+/// row is being drawn.
+///
+/// An open row is left alone whichever way its drag is going. It is already showing a reveal the
+/// reader can act on, and `releaseClaim` would spring it back open — so a drag pulling it closed,
+/// paused halfway, would have the close taken off it and be left to start again.
+func swipeHoldReleasesClaim(travelSinceClaim: CGFloat, rowIsOpen: Bool) -> Bool {
+    !rowIsOpen && abs(travelSinceClaim) < holdTravel
 }
 
 /// Deceleration a released row is left to coast on, `UIScrollView`'s normal rate.
@@ -840,12 +844,10 @@ struct LemonadeSwipeActionRowView<Content: View>: View {
             } catch {
                 return
             }
-            guard swipeHoldReleasesClaim(travelSinceClaim: travel - origin) else { return }
-            // The touch is a press now, so nothing it does later is a swipe: the settle is spent
-            // with the claim, and an `onEnded` that does turn up cannot fire an action off a
-            // translation the row stopped following. A finger still on the row claims again, and
-            // takes a new one.
-            settleOrigin = nil
+            // `settleOrigin` is deliberately left alone: a finger that lifts without moving again
+            // still gets the settle its drag earned, rather than having the gesture thrown away.
+            guard swipeHoldReleasesClaim(travelSinceClaim: travel - origin, rowIsOpen: open)
+            else { return }
             releaseClaim()
         }
     }

--- a/swiftui/Sources/Lemonade/Components/LemonadeSwipeActionRow.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeSwipeActionRow.swift
@@ -158,6 +158,36 @@ private let scrollSlack: CGFloat = 4
 /// touch. Losing the race is the only way to give it back.
 private let claimDistance: CGFloat = 24
 
+/// How long a claimed drag has to go quiet before the touch reads as a press rather than a swipe.
+///
+/// Timed from the claim rather than from the touch, because that is the only clock the row has: a
+/// gesture that loses its touch to a context menu stops delivering, so the row is never told.
+private let holdDelayNanos: UInt64 = 300_000_000
+
+/// How far a claimed drag has to have carried the row, over `holdDelayNanos`, to still read as a
+/// swipe.
+///
+/// Its own number rather than `claimDistance`, which answers a different question — how far a
+/// finger travels before the row takes the touch at all. This one is a speed floor: 24pt in 0.3s
+/// is 80pt/s, slower than any swipe that means it. It is also well short of the 52pt where the
+/// first action starts to be drawn, so a claim handed back was never showing the reader anything.
+private let holdTravel: CGFloat = 24
+
+/// Whether a claimed drag that has turned out to be a press should hand its claim back.
+///
+/// Holding a row long enough to raise a context menu rolls the finger further than the row needs
+/// to claim the drag, and the menu then takes the touch — so the drag never ends, and the claim
+/// would otherwise sit on the row until the menu is dismissed.
+///
+/// The measure is what the drag has asked for, not how long it has been asking: a row carried no
+/// further than the distance it travelled to claim the touch is showing nothing the reader can act
+/// on — the first action is not drawn at all until much further out — and a finger still on the row
+/// claims again on its next move, from where the row is being drawn. A reveal a reader is holding
+/// open to look at is well past this, and stays.
+func swipeHoldReleasesClaim(travelSinceClaim: CGFloat) -> Bool {
+    abs(travelSinceClaim) < holdTravel
+}
+
 /// Deceleration a released row is left to coast on, `UIScrollView`'s normal rate.
 private let decelerationRate: CGFloat = 0.998
 
@@ -796,16 +826,43 @@ struct LemonadeSwipeActionRowView<Content: View>: View {
         }
         .onChange(of: isDragging) { dragging in
             // A cancelled gesture never delivers `onEnded`, so the snap back has to happen here.
-            // Only the claim is released: `settleOrigin` is what `onEnded` guards on, and the
-            // order these two are observed in is not documented.
-            guard !dragging, dragOrigin != nil else { return }
-            dragOrigin = nil
-            gestureSide = nil
-            committedSide = nil
-            withAnimation(settle()) {
-                travel = open ? restingTravel : 0
-                holding = false
+            guard !dragging else { return }
+            releaseClaim()
+        }
+        // Restarted by every claim and cancelled by every release, because `dragOrigin` is what
+        // both of those write. A gesture of its own would be the obvious way to time the touch,
+        // and is the wrong one: a long press that recognises first takes the touch off the
+        // context menu the row is trying to stay out of the way of.
+        .task(id: dragOrigin) {
+            guard let origin = dragOrigin else { return }
+            do {
+                try await Task.sleep(nanoseconds: holdDelayNanos)
+            } catch {
+                return
             }
+            guard swipeHoldReleasesClaim(travelSinceClaim: travel - origin) else { return }
+            // The touch is a press now, so nothing it does later is a swipe: the settle is spent
+            // with the claim, and an `onEnded` that does turn up cannot fire an action off a
+            // translation the row stopped following. A finger still on the row claims again, and
+            // takes a new one.
+            settleOrigin = nil
+            releaseClaim()
+        }
+    }
+
+    /// Gives a claim back and settles the row where it belongs, without waiting on a gesture that
+    /// may not end for a while — or at all.
+    ///
+    /// Only the claim is released: `settleOrigin` is what `onEnded` guards on, so a drag that does
+    /// come back keeps its settle, and the order the two are observed in is not documented.
+    private func releaseClaim() {
+        guard dragOrigin != nil else { return }
+        dragOrigin = nil
+        gestureSide = nil
+        committedSide = nil
+        withAnimation(settle()) {
+            travel = open ? restingTravel : 0
+            holding = false
         }
     }
 

--- a/swiftui/Sources/Lemonade/Components/LemonadeSwipeActionRow.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeSwipeActionRow.swift
@@ -844,6 +844,11 @@ struct LemonadeSwipeActionRowView<Content: View>: View {
             } catch {
                 return
             }
+            // The sleep only throws for a cancellation that lands while it is running; one that
+            // arrives as it returns leaves the task to run on. So the claim this woke for is
+            // checked rather than assumed — it may have ended, or a second drag may have taken
+            // its own by now, and neither is this task's to hand back.
+            guard !Task.isCancelled, dragOrigin == origin else { return }
             // `settleOrigin` is deliberately left alone: a finger that lifts without moving again
             // still gets the settle its drag earned, rather than having the gesture thrown away.
             guard swipeHoldReleasesClaim(travelSinceClaim: travel - origin, rowIsOpen: open)

--- a/swiftui/Tests/LemonadeTests/LemonadeSwipeHoldTests.swift
+++ b/swiftui/Tests/LemonadeTests/LemonadeSwipeHoldTests.swift
@@ -3,27 +3,34 @@ import XCTest
 
 /// Covers `swipeHoldReleasesClaim` — whether a touch that has gone quiet keeps the drag it claimed
 /// on its way to a context menu. The measure is the row's travel since the claim, against the 24pt
-/// of `holdTravel`.
+/// of `holdTravel`, and only a closed row ever hands a claim back.
 final class LemonadeSwipeHoldTests: XCTestCase {
+
+    private func releases(_ travelSinceClaim: CGFloat, open: Bool = false) -> Bool {
+        swipeHoldReleasesClaim(travelSinceClaim: travelSinceClaim, rowIsOpen: open)
+    }
 
     /// The drift a finger rolls through while it waits out a long press: measured at 7.3pt on the
     /// row that raised this, and nothing a reader can act on.
     func testDriftUnderAPressHandsTheClaimBack() {
-        XCTAssertTrue(swipeHoldReleasesClaim(travelSinceClaim: 7.3))
-        XCTAssertTrue(swipeHoldReleasesClaim(travelSinceClaim: -7.3))
+        XCTAssertTrue(releases(7.3))
+        XCTAssertTrue(releases(-7.3))
     }
 
     /// The boundary. A drag that has carried the row this far has asked for something, and a finger
     /// resting over it does not take it away.
     func testTheBoundaryKeepsTheClaim() {
-        XCTAssertTrue(swipeHoldReleasesClaim(travelSinceClaim: 23.9))
-        XCTAssertFalse(swipeHoldReleasesClaim(travelSinceClaim: 24))
+        XCTAssertTrue(releases(23.9))
+        XCTAssertFalse(releases(24))
     }
 
-    /// The case the slack is really there for: a reveal a reader is holding open to look at stays
-    /// open under their finger.
-    func testAReadableRevealKeepsIt() {
-        XCTAssertFalse(swipeHoldReleasesClaim(travelSinceClaim: 76))
+    /// An open row keeps its claim however little the drag has moved it. It is already showing a
+    /// reveal, and handing the claim back would spring it open again under the finger — so a drag
+    /// pulling it closed, paused halfway, would lose the close it had asked for.
+    func testAnOpenRowAlwaysKeepsItsClaim() {
+        XCTAssertFalse(releases(0, open: true))
+        XCTAssertFalse(releases(7.3, open: true))
+        XCTAssertFalse(releases(-20, open: true))
     }
 
     /// The invariant the slack exists to hold, checked against the reveal geometry rather than
@@ -32,6 +39,9 @@ final class LemonadeSwipeHoldTests: XCTestCase {
     /// `holdTravel` and the travel at which the first action starts to be drawn are set apart in
     /// different places, and nothing but this ties them together. Raising the slack past that
     /// point would let a finger resting on a row take a reveal the reader can see away from them.
+    ///
+    /// Read as travel rather than as a delta, which is what it is at the call site for the row this
+    /// guards: a closed row is claimed at rest, so the claim's origin is zero.
     func testAHoldNeverTakesBackARevealTheReaderCanSee() {
         let reveal: CGFloat = 76
         let actionWidth: CGFloat = 48
@@ -45,7 +55,7 @@ final class LemonadeSwipeHoldTests: XCTestCase {
             )
             guard drawn.scale > 0 else { continue }
             XCTAssertFalse(
-                swipeHoldReleasesClaim(travelSinceClaim: travel),
+                releases(travel),
                 "travel \(travel) draws the action at scale \(drawn.scale) but would be handed back"
             )
         }

--- a/swiftui/Tests/LemonadeTests/LemonadeSwipeHoldTests.swift
+++ b/swiftui/Tests/LemonadeTests/LemonadeSwipeHoldTests.swift
@@ -25,4 +25,29 @@ final class LemonadeSwipeHoldTests: XCTestCase {
     func testAReadableRevealKeepsIt() {
         XCTAssertFalse(swipeHoldReleasesClaim(travelSinceClaim: 76))
     }
+
+    /// The invariant the slack exists to hold, checked against the reveal geometry rather than
+    /// against a number: a claim is only ever handed back while the row is showing nothing.
+    ///
+    /// `holdTravel` and the travel at which the first action starts to be drawn are set apart in
+    /// different places, and nothing but this ties them together. Raising the slack past that
+    /// point would let a finger resting on a row take a reveal the reader can see away from them.
+    func testAHoldNeverTakesBackARevealTheReaderCanSee() {
+        let reveal: CGFloat = 76
+        let actionWidth: CGFloat = 48
+        for step in 0...Int(reveal * 2) {
+            let travel = CGFloat(step) / 2
+            let drawn = resolveSwipeStripReveal(
+                travel: travel,
+                actionReveal: reveal,
+                stripReveal: reveal,
+                actionWidth: actionWidth
+            )
+            guard drawn.scale > 0 else { continue }
+            XCTAssertFalse(
+                swipeHoldReleasesClaim(travelSinceClaim: travel),
+                "travel \(travel) draws the action at scale \(drawn.scale) but would be handed back"
+            )
+        }
+    }
 }

--- a/swiftui/Tests/LemonadeTests/LemonadeSwipeHoldTests.swift
+++ b/swiftui/Tests/LemonadeTests/LemonadeSwipeHoldTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+@testable import Lemonade
+
+/// Covers `swipeHoldReleasesClaim` — whether a touch that has gone quiet keeps the drag it claimed
+/// on its way to a context menu. The measure is the row's travel since the claim, against the 24pt
+/// of `holdTravel`.
+final class LemonadeSwipeHoldTests: XCTestCase {
+
+    /// The drift a finger rolls through while it waits out a long press: measured at 7.3pt on the
+    /// row that raised this, and nothing a reader can act on.
+    func testDriftUnderAPressHandsTheClaimBack() {
+        XCTAssertTrue(swipeHoldReleasesClaim(travelSinceClaim: 7.3))
+        XCTAssertTrue(swipeHoldReleasesClaim(travelSinceClaim: -7.3))
+    }
+
+    /// The boundary. A drag that has carried the row this far has asked for something, and a finger
+    /// resting over it does not take it away.
+    func testTheBoundaryKeepsTheClaim() {
+        XCTAssertTrue(swipeHoldReleasesClaim(travelSinceClaim: 23.9))
+        XCTAssertFalse(swipeHoldReleasesClaim(travelSinceClaim: 24))
+    }
+
+    /// The case the slack is really there for: a reveal a reader is holding open to look at stays
+    /// open under their finger.
+    func testAReadableRevealKeepsIt() {
+        XCTAssertFalse(swipeHoldReleasesClaim(travelSinceClaim: 76))
+    }
+}


### PR DESCRIPTION
# Summary

Closes #370.

A `SwipeActionRow` whose content also carries a `.contextMenu` was left visibly offset after the menu was dismissed, then sprang back. Holding the row drifts the finger past the 24pt claim distance, so the drag claims the touch and nudges the row open; the menu then takes the touch, so the drag never ends. `isDragging` is a `@GestureState` and only clears on dismissal — the cancel path was correct but fired far too late.

The row now times the claim itself rather than waiting on a gesture that may never end. 0.3s after a drag claims the row, if the row has been carried less than 24pt since, the claim goes back and the row settles. A finger still on the row claims again on its next move, from where the row is being drawn, so a slow swipe carries on unaffected.

The rule is not context-menu-specific: a claim that took the row nowhere the reader can see was not a swipe. Anything else that steals a touch — a drag session, a long-press sheet — gets the same treatment without being named.

## Figma component
- [Design](https://www.figma.com/design/91S16rhVrl5wivqV66fNjm/%F0%9F%8D%8B-Lemonade-DS---Components?node-id=21709-6930&t=pJs6USLSPXUzgns6-11)

## Evidences
https://github.com/user-attachments/assets/d7958e31-ea5e-4b76-af11-fe7788ede5a2

## API Dump

No public API changes.

## How to test

1. Sample app → **SwipeActionRow** → the **Swipe or hold** card near the bottom. The row carries a `.contextMenu`.
2. Press and hold with normal finger drift → the menu appears; dismiss it by tapping away → the row is already at rest, with no spring-back.
3. Swipe the row open → still opens and settles normally.
4. Tap the row → its action still fires.
5. Swipe out, then pause with your finger still down → the row stays where you left it and does not snap shut.
6. Scroll the list → unaffected.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added all necessary code documentation and specifications
- [x] I have performed manual tests to ensure the system is working as expected
- [x] If these changes use a new version of an API, is that new version on staging and production?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

