### PR TITLE
fix(toolbar-icon-button): build for the macOS the package declares

### DIFF
--- a/swiftui/Sources/Lemonade/Components/LemonadeToolbarIconButton.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeToolbarIconButton.swift
@@ -106,9 +106,9 @@ private struct LemonadeToolbarIconMenuView<Content: View>: View {
 
     @ViewBuilder
     private var menu: some View {
-        // `macOS 13.0` spelled out rather than left to the `*`: this file is not inside the
-        // `#if os(iOS)` its neighbours are, so it compiles for the macOS 12 the package declares,
-        // and `*` waves every one of those builds into a branch `.button` is not in yet.
+        // Unlike its neighbours, this file is not wrapped in `#if os(iOS)`, so it also builds for
+        // the package's macOS 12 target, which lacks `.menuStyle(.button)`. `macOS 13.0` is named
+        // here because `*` alone would let macOS 12 into this branch.
         if #available(iOS 16.0, macOS 13.0, *) {
             rawMenu
                 // Without this a `Menu` ignores `.buttonStyle` entirely, so a prominent tint lands

--- a/swiftui/Sources/Lemonade/Components/LemonadeToolbarIconButton.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeToolbarIconButton.swift
@@ -106,7 +106,10 @@ private struct LemonadeToolbarIconMenuView<Content: View>: View {
 
     @ViewBuilder
     private var menu: some View {
-        if #available(iOS 16.0, *) {
+        // `macOS 13.0` spelled out rather than left to the `*`: this file is not inside the
+        // `#if os(iOS)` its neighbours are, so it compiles for the macOS 12 the package declares,
+        // and `*` waves every one of those builds into a branch `.button` is not in yet.
+        if #available(iOS 16.0, macOS 13.0, *) {
             rawMenu
                 // Without this a `Menu` ignores `.buttonStyle` entirely, so a prominent tint lands
                 // on the glyph instead of filling the button.


### PR DESCRIPTION
# Summary

`Package.swift` declares `.macOS(.v12)`, but the library has not compiled for it since #368:

```
LemonadeToolbarIconButton.swift:113: error: 'button' is only available in macOS 13.0 or newer
```

`if #available(iOS 16.0, *)` reads as "iOS 16, or anything that is not iOS", and anything that is not iOS includes macOS 12 — which does not have `.menuStyle(.button)` yet. The guard now names `macOS 13.0` itself.

The file's neighbours get away with the same shape of guard because they sit inside `#if os(iOS)` — `LemonadeTopBar.swift` wholesale, `LemonadeSegmentedControl.swift`'s inside `#if canImport(UIKit)`. `LemonadeToolbarIconButton.swift` is not gated, so it is the only one of the 13 `#available(iOS …, *)` guards in the package that reaches a macOS build. I checked the other twelve; none of them do.

This also takes `swift test` down with it, since the test bundle builds for the host — which is how it turned up, while rebasing #373.

## Figma component

n/a

## Screenshot

n/a — a build fix, no rendered change. Behaviour on iOS is untouched: the branch it guards is unchanged, and `#available(iOS 16.0, macOS 13.0, *)` still selects it on iOS 16+.

## API Dump

No public API changes.

## Why CI did not catch it

`swiftui_ci.yml` builds the framework and the sample app for `generic/platform=iOS Simulator` and nothing else, so no macOS build runs and `swift test` is never invoked. Whether CI should cover the platforms `Package.swift` advertises is worth deciding separately — happy to raise it as an issue if you want it tracked.

## How to test

From `swiftui/`:

```bash
swift build   # fails on main, succeeds here
swift test    # 88 tests, 1 skipped
```

And unchanged on iOS:

```bash
./scripts/generate-ios-project.sh
xcodebuild build -project Lemonade.xcodeproj -scheme Lemonade \
  -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO
xcodebuild build -project Lemonade.xcodeproj -scheme LemonadeSampleApp \
  -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO
```

All four pass locally.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have added all necessary code documentation and specifications
- [ ] I have performed manual tests to ensure the system is working as expected
- [ ] I have created automated tests to replicate my manual testing automatically
- [ ] Did I add/update translations?
- [ ] I have considered whether my changes affect E2E tests
- [ ] If these changes rely on a feature flag, does it have the correct value for staging and production?
- [ ] If these changes use a new version of an API, is that new version on staging and production?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DVDDeRkhoSkBeas4B2uX1Z