### PR TITLE
fix(top-bar): keep the soft scroll edge on iOS 27

### DIFF
--- a/swiftui/Sources/Lemonade/Modifiers/LemonadeTopBar.swift
+++ b/swiftui/Sources/Lemonade/Modifiers/LemonadeTopBar.swift
@@ -639,9 +639,12 @@ private extension ToolbarContent {
 private extension View {
     /// iOS 27 defaults the top edge to `.hard`; pinning `.soft` keeps the progressive blur
     /// under the bar. Consumers can still override it on their scroll view.
+    ///
+    /// Gated to the Xcode 27 compiler: on iOS 27, an app built against the iOS 26 SDK draws
+    /// `.soft` only over the status bar, which reads worse than the system's `.hard` bar.
     @ViewBuilder
     func lemonadeSoftTopScrollEdge() -> some View {
-        #if compiler(>=6.2)
+        #if compiler(>=6.4)
         if #available(iOS 26, *) {
             self.scrollEdgeEffectStyle(.soft, for: .top)
         } else {

--- a/swiftui/Sources/Lemonade/Modifiers/LemonadeTopBar.swift
+++ b/swiftui/Sources/Lemonade/Modifiers/LemonadeTopBar.swift
@@ -55,6 +55,7 @@ private struct BasicTopBarModifier<Toolbar: ToolbarContent, BottomContent: View>
 
     func body(content: Content) -> some View {
         content
+            .lemonadeSoftTopScrollEdge()
             .lemonadeNavigationTitle(title: collapsedLabel ?? label, subheading: subheading)
             .navigationBarBackButtonHidden(navigationAction?.action == .close)
             .toolbar {
@@ -90,6 +91,7 @@ private struct SearchTopBarModifier<Toolbar: ToolbarContent, BottomContent: View
 
     func body(content: Content) -> some View {
         content
+            .lemonadeSoftTopScrollEdge()
             .lemonadeNavigationTitle(title: expandedLabel ?? label, subheading: subheading)
             .searchable(
                 text: $searchInput,
@@ -526,6 +528,7 @@ private struct NativeCompactLargeTopBarModifier<Toolbar: ToolbarContent>: ViewMo
 
     func body(content: Content) -> some View {
         content
+            .lemonadeSoftTopScrollEdge()
             .coordinateSpace(name: "compactLargeNativeScroll")
             .onPreferenceChange(NativeScrollOffsetKey.self) { offset in
                 guard abs(offset - lastScrollOffset) > 2 else { return }
@@ -570,6 +573,7 @@ private struct NativeCompactLargeSearchTopBarModifier<Toolbar: ToolbarContent>: 
 
     func body(content: Content) -> some View {
         content
+            .lemonadeSoftTopScrollEdge()
             .coordinateSpace(name: "compactLargeSearchNativeScroll")
             .onPreferenceChange(NativeScrollOffsetKey.self) { offset in
                 guard abs(offset - lastScrollOffset) > 2 else { return }
@@ -623,6 +627,23 @@ private extension ToolbarContent {
         #if compiler(>=6.2)
         if #available(iOS 26, *) {
             self.sharedBackgroundVisibility(.hidden)
+        } else {
+            self
+        }
+        #else
+        self
+        #endif
+    }
+}
+
+private extension View {
+    /// iOS 27 defaults the top edge to `.hard`; pinning `.soft` keeps the progressive blur
+    /// under the bar. Consumers can still override it on their scroll view.
+    @ViewBuilder
+    func lemonadeSoftTopScrollEdge() -> some View {
+        #if compiler(>=6.2)
+        if #available(iOS 26, *) {
+            self.scrollEdgeEffectStyle(.soft, for: .top)
         } else {
             self
         }


### PR DESCRIPTION
# Summary
iOS 27 changed the default top scroll edge effect from `.soft` to `.hard`, so the TopBar loses its progressive blur and gets a solid bar with a divider instead.

This pins `.scrollEdgeEffectStyle(.soft, for: .top)` on the four TopBar variants that use the native navigation bar (basic, search, compact large, compact large + search). Consumers can still override it on their own scroll view.

It only applies when Lemonade is compiled with Xcode 27 (`#if compiler(>=6.4)`). On iOS 27, an app built with Xcode 26 draws `.soft` only over the status bar, leaving the title on sharp content, so those apps keep the system's solid bar instead. On iOS 26 `.soft` is already the default, so nothing changes there.

On an iPhone running iOS 27 (the Xcode 26 build with this PR doesn't contain the call, so it renders the same as without it):

| Build | Without this PR | With this PR |
|---|---|---|
| Xcode 26 | Solid bar | Solid bar (unchanged) |
| Xcode 27 | Solid bar | Soft blur |

The CocoaPods xcframework is built by CI, so it picks up the soft blur once the release runner uses Xcode 27.

### XCode 27 + iOS 27
![image](https://github.com/user-attachments/assets/a4e20795-88a8-4adb-b0d1-c088c81adb63)

### XCode 26 + iOS 27 (forcing `.soft`)
![image](https://github.com/user-attachments/assets/a75c540f-b011-4c31-a2d7-2870de230d5d)

### XCode 26 + iOS 27 (not forcing `.soft`)
![image](https://github.com/user-attachments/assets/9d5308b8-5de0-40d9-a68d-4a76a3f51a45)

### XCode 26 + iOS 26 (`.soft` is the default)
![image](https://github.com/user-attachments/assets/2c4cd32a-d7b0-4278-b501-ccfb79bdb555)

## Figma component
N/A

## Screenshot
N/A

## API Dump
No public API changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
