### PR TITLE
fix(dropdown): align the Compose dropdown with the Figma spec

### DIFF
--- a/kmp/expressive/src/commonMain/kotlin/com/teya/lemonade/Dropdown.kt
+++ b/kmp/expressive/src/commonMain/kotlin/com/teya/lemonade/Dropdown.kt
@@ -1,21 +1,21 @@
 package com.teya.lemonade
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
-import androidx.compose.material3.MenuDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.PopupProperties
 import com.teya.lemonade.core.LemonadeAssetSize
 import com.teya.lemonade.core.LemonadeIcons
-import androidx.compose.material3.Text as M3Text
 
 /**
  * A dropdown menu overlay following the Lemonade Design System.
@@ -53,6 +53,8 @@ import androidx.compose.material3.Text as M3Text
  * - Uses [LemonadeTheme.shapes.radius500] for rounded corners.
  * - Background color is [LemonadeTheme.colors.background.bgDefault].
  * - Vertical offset is [LemonadeTheme.spaces.spacing200] from the anchor.
+ * - Items are inset [LemonadeTheme.spaces.spacing100] from the panel and stack flush against one
+ *   another.
  * - The dropdown keeps whichever system bars the host window hides, never shows one the host hides.
  *
  * @param expanded whether the dropdown menu is currently visible
@@ -83,8 +85,10 @@ public fun LemonadeUi.Dropdown(
     DropdownMenu(
         expanded = expanded,
         onDismissRequest = onDismissRequest,
+        // The inset belongs on the menu: padding each item opens a gap between rows.
         modifier = Modifier
-            .defaultMinSize(minWidth = dropdownMinWidth),
+            .defaultMinSize(minWidth = dropdownMinWidth)
+            .padding(horizontal = LemonadeTheme.spaces.spacing100),
         offset = DpOffset(
             y = LemonadeTheme.spaces.spacing200,
             x = LemonadeTheme.spaces.spacing0,
@@ -159,6 +163,7 @@ public fun LemonadeUi.DropdownItem(
                     icon = trailingIcon,
                     contentDescription = null,
                     size = LemonadeAssetSize.Small,
+                    tint = LemonadeTheme.colors.content.contentSecondary,
                 )
             }
         } else {
@@ -219,6 +224,7 @@ public fun LemonadeUi.DropdownItem(
                     icon = leadingIcon,
                     contentDescription = null,
                     size = LemonadeAssetSize.Medium,
+                    tint = LemonadeTheme.colors.content.contentSecondary,
                 )
             }
         } else {
@@ -242,15 +248,44 @@ private fun CoreDropdownItem(
     DropdownMenuItem(
         onClick = onClick,
         modifier = modifier
-            .padding(LemonadeTheme.spaces.spacing100)
+            .alpha(alpha = if (enabled) 1f else LemonadeTheme.opacities.state.opacityDisabled)
             .clip(LemonadeTheme.shapes.radius400),
-        leadingIcon = leadingSlot,
-        trailingIcon = trailingSlot,
+        leadingIcon = leadingSlot?.let { slot ->
+            {
+                SpacedFromLabel(
+                    padding = PaddingValues(end = LemonadeTheme.spaces.spacing100),
+                    content = slot,
+                )
+            }
+        },
+        trailingIcon = trailingSlot?.let { slot ->
+            {
+                SpacedFromLabel(
+                    padding = PaddingValues(start = LemonadeTheme.spaces.spacing100),
+                    content = slot,
+                )
+            }
+        },
         enabled = enabled,
-        contentPadding = PaddingValues(LemonadeTheme.spaces.spacing300),
-        colors = MenuDefaults.itemColors(),
+        contentPadding = PaddingValues(
+            horizontal = LemonadeTheme.spaces.spacing300,
+            vertical = LemonadeTheme.spaces.spacing200,
+        ),
         text = {
-            M3Text(text = text)
+            LemonadeUi.Text(
+                text = text,
+                textStyle = LemonadeTheme.typography.bodyMediumRegular,
+            )
         },
     )
+}
+
+@Composable
+private fun SpacedFromLabel(
+    padding: PaddingValues,
+    content: @Composable () -> Unit,
+) {
+    Box(modifier = Modifier.padding(paddingValues = padding)) {
+        content()
+    }
 }


### PR DESCRIPTION
# Summary

The Compose dropdown had drifted from the design. Rows sat 8dp apart instead of flush, the label used Material's 14sp medium instead of the 16sp regular body style, icons rendered at full-strength `contentPrimary`, and disabled items dimmed only their label while the icons stayed sharp. This brings the component back in line with Figma. Nothing about the public API changes — the fixes are all internal.

## Figma component

https://www.figma.com/design/91S16rhVrl5wivqV66fNjm/%F0%9F%8D%8B-Lemonade-DS---Components?node-id=17678-59

## What changed

- Item content padding is now 12 horizontal / 8 vertical (`spacing300` / `spacing200`), was 12 all round.
- The label uses `bodyMediumRegular` (16/24) via `LemonadeUi.Text`, replacing Material's `Text` which inherited `labelLarge`.
- Leading and trailing icons are tinted `contentSecondary`. They were rendering `contentPrimary`, because `LemonadeUi.Icon` takes its colour as a parameter and never reads the `LocalContentColor` that `MenuDefaults.itemColors` sets — so those colours were inert.
- Disabled items dim the whole row with `opacities.state.opacityDisabled`, the same `Modifier.alpha` treatment `Button` and `Checkbox` use. Previously Material's 0.38 reached the label only.
- The 4dp inset moved off each item onto the menu column, so rows stack flush. Carried per item it was doubling into an 8dp gap between neighbours.
- The gap between an icon and the label is 12dp, up from Material's hardcoded 8dp.

Three details of the design are out of reach while this wraps `DropdownMenu`: the column's fixed 8dp top/bottom padding, the panel's Material elevation shadow in place of the `shadow-large` token, and the 48dp row height against the design's 40dp. All three follow from wrapping `DropdownMenu`; a `Popup`-based panel would retire them together. They are recorded here rather than in the KDoc, per the comment rules added in #386 — rationale belongs in the PR, not in a comment.

Section headings, dividers and supporting text are in the design but not in this component — each needs public API of its own, so they are out of scope here.

## Screenshot

Verified on a Pixel 10a across the Basic, Leading Icons and Disabled Items samples. Screenshots to be attached.

Related: #392 covers the root cause behind the icon tint fix.

## API Dump

No public API changes.

