### PR TITLE
fix(theme): make Icon and Text read LocalContentColors

### DIFF
--- a/kmp/tokens/src/commonMain/kotlin/com/teya/lemonade/LemonadeLocals.kt
+++ b/kmp/tokens/src/commonMain/kotlin/com/teya/lemonade/LemonadeLocals.kt
@@ -2,6 +2,7 @@ package com.teya.lemonade
 
 import androidx.compose.foundation.Indication
 import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
 import com.teya.lemonade.core.LemonadeTextStyle
@@ -26,7 +27,7 @@ public val LocalTypographies: ProvidableCompositionLocal<LemonadeTypographyProvi
     }
 
 @InternalLemonadeApi
-public val LocalContentColors: ProvidableCompositionLocal<Color> = staticCompositionLocalOf {
+public val LocalContentColors: ProvidableCompositionLocal<Color> = compositionLocalOf {
     error("No default Content Colors set in the LocalContentColors for theme")
 }
 

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Icon.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Icon.kt
@@ -26,7 +26,7 @@ import com.teya.lemonade.core.LemonadeIcons
  *     icon = LemonadeIcons.Close,
  *     contentDescription = "Close icon",
  *     size = LemonadeAssetSize.Medium,
- *     tint = LocalColors.current.content.contentPrimary,
+ *     tint = LocalColors.current.content.contentSecondary,
  * )
  * ```
  *
@@ -34,7 +34,7 @@ import com.teya.lemonade.core.LemonadeIcons
  * @param contentDescription a **localized** text that describes the icon or its action.
  *  Optional, but strongly recommended
  * @param size [LemonadeAssetSize] applied to the icon, defaults to [LemonadeAssetSize.Medium]
- * @param tint tint color applied to the icon, defaults to the primary content color of [LemonadeTheme]
+ * @param tint tint color applied to the icon, defaults to [LocalContentColors]
  * @param modifier optional [Modifier] for additional styling and layout adjustments
  */
 @Composable
@@ -42,7 +42,7 @@ public fun LemonadeUi.Icon(
     icon: LemonadeIcons,
     contentDescription: String?,
     size: LemonadeAssetSize = LemonadeAssetSize.Medium,
-    tint: Color = LocalColors.current.content.contentPrimary,
+    tint: Color = LocalContentColors.current,
     modifier: Modifier = Modifier,
 ) {
     CoreIcon(

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/LemonadeTheme.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/LemonadeTheme.kt
@@ -30,7 +30,7 @@ public fun LemonadeTheme(
         } else {
             LemonadeLightThemedColors
         },
-        LocalContentColors provides colors.content.contentNeutral,
+        LocalContentColors provides colors.content.contentPrimary,
         LocalTextStyles provides typography.bodyMediumRegular,
         LocalRadius provides radius,
         LocalShapes provides shapes,

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Text.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Text.kt
@@ -40,7 +40,8 @@ private const val NATURAL_LINE_HEIGHT_RATIO: Float = 1.20f
  * @param modifier [Modifier] applied to the text layout
  * @param textStyle Lemonade typography token to apply
  * @param textAlign alignment of the text within its container
- * @param color text color; when [Color.Unspecified] the color from [textStyle] is used
+ * @param color text color, defaults to [LocalContentColors]; [Color.Unspecified] falls back to
+ *   the color from [textStyle]
  * @param overflow how text overflow is handled
  * @param maxLines maximum number of lines to show
  * @param minLines minimum number of lines to show
@@ -56,7 +57,7 @@ public fun LemonadeUi.Text(
     modifier: Modifier = Modifier,
     textStyle: LemonadeTextStyle = LocalTextStyles.current,
     textAlign: TextAlign = TextAlign.Unspecified,
-    color: Color = LocalColors.current.content.contentPrimary,
+    color: Color = LocalContentColors.current,
     overflow: TextOverflow = TextOverflow.Clip,
     maxLines: Int = Int.MAX_VALUE,
     minLines: Int = 1,
@@ -98,7 +99,8 @@ public fun LemonadeUi.Text(
  * @param modifier [Modifier] applied to the text layout
  * @param textStyle Lemonade typography token to apply
  * @param textAlign alignment of the text within its container
- * @param color text color; when [Color.Unspecified] the color from [textStyle] is used
+ * @param color text color, defaults to [LocalContentColors]; [Color.Unspecified] falls back to
+ *   the color from [textStyle]
  * @param overflow how text overflow is handled
  * @param maxLines maximum number of lines to show
  * @param minLines minimum number of lines to show
@@ -114,7 +116,7 @@ public fun LemonadeUi.Text(
     modifier: Modifier = Modifier,
     textStyle: LemonadeTextStyle = LocalTextStyles.current,
     textAlign: TextAlign = TextAlign.Unspecified,
-    color: Color = LocalColors.current.content.contentPrimary,
+    color: Color = LocalContentColors.current,
     overflow: TextOverflow = TextOverflow.Clip,
     maxLines: Int = Int.MAX_VALUE,
     minLines: Int = 1,


### PR DESCRIPTION
# Summary

`LemonadeTheme` provided `LocalContentColors`, but nothing read it. That left the design system with no content-colour channel: a parent couldn't recolour the icons and text below it. Closes #392.

- `LemonadeUi.Icon`'s `tint` and `LemonadeUi.Text`'s `color` now default to `LocalContentColors.current`.
- `LemonadeTheme` now provides `contentPrimary` instead of `contentNeutral`. `contentPrimary` was the old hard-coded default, so nothing changes visually, even if the two tokens diverge in a future export.
- `LocalContentColors` switches from `staticCompositionLocalOf` to `compositionLocalOf`. A subtree can now provide its own colour and only the `Icon`/`Text` that read it recompose, not the whole subtree. Material's `LocalContentColor` works the same way.

Containers such as Dropdown, Button and Chip don't provide the channel to their slots yet. That follow-up is tracked in #395.

## Figma component

N/A

## Screenshot

N/A: no visual change.

## API Dump

No public API changes. `bcv-check.sh --ci` reports `NO_CHANGES`: changing a default value or a local's factory doesn't alter any signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G7X7yCKEAEyfeFzv9MDXj1
