### PR TITLE
feat(sample): show every semantic colour as a swatch grid

### DIFF
--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ColorSwatchSection.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ColorSwatchSection.kt
@@ -34,19 +34,22 @@ internal data class ColorSwatchGroup(
 
 @Composable
 internal fun ColorSwatchSection(
-    group: ColorSwatchGroup,
+    title: String?,
+    swatches: List<ColorSwatch>,
     outlined: Boolean = false,
 ) {
     Column(
         verticalArrangement = Arrangement.spacedBy(space = LemonadeTheme.spaces.spacing200),
         modifier = Modifier.padding(vertical = LemonadeTheme.spaces.spacing400),
     ) {
-        LemonadeUi.Text(
-            text = group.title,
-            textStyle = LemonadeTheme.typography.headingXXSmall,
-            modifier = Modifier.padding(horizontal = LemonadeTheme.spaces.spacing100),
-        )
-        group.swatches.chunked(size = COLUMNS).forEach { row ->
+        if (title != null) {
+            LemonadeUi.Text(
+                text = title,
+                textStyle = LemonadeTheme.typography.headingXXSmall,
+                modifier = Modifier.padding(horizontal = LemonadeTheme.spaces.spacing100),
+            )
+        }
+        swatches.chunked(size = COLUMNS).forEach { row ->
             Row(
                 horizontalArrangement = Arrangement.spacedBy(space = LemonadeTheme.spaces.spacing200),
             ) {

--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ColorSwatchSection.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ColorSwatchSection.kt
@@ -10,8 +10,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -28,28 +26,28 @@ internal data class ColorSwatch(
 )
 
 internal data class ColorSwatchGroup(
-    val title: String,
+    val id: String,
+    val title: String?,
     val swatches: List<ColorSwatch>,
 )
 
 @Composable
 internal fun ColorSwatchSection(
-    title: String?,
-    swatches: List<ColorSwatch>,
+    group: ColorSwatchGroup,
     outlined: Boolean = false,
 ) {
     Column(
         verticalArrangement = Arrangement.spacedBy(space = LemonadeTheme.spaces.spacing200),
         modifier = Modifier.padding(vertical = LemonadeTheme.spaces.spacing400),
     ) {
-        if (title != null) {
+        if (group.title != null) {
             LemonadeUi.Text(
-                text = title,
+                text = group.title,
                 textStyle = LemonadeTheme.typography.headingXXSmall,
                 modifier = Modifier.padding(horizontal = LemonadeTheme.spaces.spacing100),
             )
         }
-        swatches.chunked(size = COLUMNS).forEach { row ->
+        group.swatches.chunked(size = COLUMNS).forEach { row ->
             Row(
                 horizontalArrangement = Arrangement.spacedBy(space = LemonadeTheme.spaces.spacing200),
             ) {
@@ -78,9 +76,10 @@ private fun ColorSwatchBlock(
         verticalArrangement = Arrangement.SpaceBetween,
         modifier = modifier
             .height(height = SwatchHeight)
-            .clip(shape = LemonadeTheme.shapes.radius600)
-            .background(color = swatch.fill)
-            .then(
+            .background(
+                color = swatch.fill,
+                shape = LemonadeTheme.shapes.radius600,
+            ).then(
                 if (outlined) {
                     Modifier.border(
                         width = LemonadeTheme.borderWidths.base.border25,
@@ -98,8 +97,7 @@ private fun ColorSwatchBlock(
         LemonadeUi.Text(
             text = swatch.path,
             textStyle = LemonadeTheme.typography.bodyXSmallRegular,
-            color = swatch.label,
-            modifier = Modifier.alpha(alpha = LemonadeTheme.opacities.base.opacity70),
+            color = swatch.label.copy(alpha = swatch.label.alpha * LemonadeTheme.opacities.base.opacity70),
         )
         LemonadeUi.Text(
             text = swatch.name,

--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ColorSwatchSection.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ColorSwatchSection.kt
@@ -1,6 +1,7 @@
 package com.teya.lemonade
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -32,7 +33,10 @@ internal data class ColorSwatchGroup(
 )
 
 @Composable
-internal fun ColorSwatchSection(group: ColorSwatchGroup) {
+internal fun ColorSwatchSection(
+    group: ColorSwatchGroup,
+    outlined: Boolean = false,
+) {
     Column(
         verticalArrangement = Arrangement.spacedBy(space = LemonadeTheme.spaces.spacing200),
         modifier = Modifier.padding(vertical = LemonadeTheme.spaces.spacing400),
@@ -49,6 +53,7 @@ internal fun ColorSwatchSection(group: ColorSwatchGroup) {
                 row.forEach { swatch ->
                     ColorSwatchBlock(
                         swatch = swatch,
+                        outlined = outlined,
                         modifier = Modifier.weight(weight = 1f),
                     )
                 }
@@ -63,6 +68,7 @@ internal fun ColorSwatchSection(group: ColorSwatchGroup) {
 @Composable
 private fun ColorSwatchBlock(
     swatch: ColorSwatch,
+    outlined: Boolean,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -71,7 +77,17 @@ private fun ColorSwatchBlock(
             .height(height = SwatchHeight)
             .clip(shape = LemonadeTheme.shapes.radius600)
             .background(color = swatch.fill)
-            .padding(
+            .then(
+                if (outlined) {
+                    Modifier.border(
+                        width = LemonadeTheme.borderWidths.base.border25,
+                        color = LemonadeTheme.colors.border.borderNeutralLow,
+                        shape = LemonadeTheme.shapes.radius600,
+                    )
+                } else {
+                    Modifier
+                },
+            ).padding(
                 horizontal = LemonadeTheme.spaces.spacing400,
                 vertical = LemonadeTheme.spaces.spacing500,
             ),

--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ColorSwatchSection.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ColorSwatchSection.kt
@@ -1,0 +1,85 @@
+package com.teya.lemonade
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+private val SwatchHeight: Dp = 162.dp
+
+internal data class ColorSwatch(
+    val path: String,
+    val name: String,
+    val fill: Color,
+    val label: Color,
+)
+
+internal data class ColorSwatchGroup(
+    val title: String,
+    val swatches: List<ColorSwatch>,
+)
+
+@Composable
+internal fun ColorSwatchSection(group: ColorSwatchGroup) {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(space = LemonadeTheme.spaces.spacing200),
+        modifier = Modifier.padding(vertical = LemonadeTheme.spaces.spacing400),
+    ) {
+        LemonadeUi.Text(
+            text = group.title,
+            textStyle = LemonadeTheme.typography.headingXXSmall,
+            modifier = Modifier.padding(horizontal = LemonadeTheme.spaces.spacing100),
+        )
+        group.swatches.chunked(size = 2).forEach { row ->
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(space = LemonadeTheme.spaces.spacing200),
+            ) {
+                row.forEach { swatch ->
+                    ColorSwatchBlock(
+                        swatch = swatch,
+                        modifier = Modifier.weight(weight = 1f),
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ColorSwatchBlock(
+    swatch: ColorSwatch,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        verticalArrangement = Arrangement.SpaceBetween,
+        modifier = modifier
+            .height(height = SwatchHeight)
+            .clip(shape = LemonadeTheme.shapes.radius600)
+            .background(color = swatch.fill)
+            .padding(
+                horizontal = LemonadeTheme.spaces.spacing400,
+                vertical = LemonadeTheme.spaces.spacing500,
+            ),
+    ) {
+        LemonadeUi.Text(
+            text = swatch.path,
+            textStyle = LemonadeTheme.typography.bodyXSmallRegular,
+            color = swatch.label,
+            modifier = Modifier.alpha(alpha = LemonadeTheme.opacities.base.opacity70),
+        )
+        LemonadeUi.Text(
+            text = swatch.name,
+            textStyle = LemonadeTheme.typography.bodyXSmallMedium,
+            color = swatch.label,
+        )
+    }
+}

--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ColorSwatchSection.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ColorSwatchSection.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
@@ -13,6 +14,8 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+
+private const val COLUMNS = 2
 
 private val SwatchHeight: Dp = 162.dp
 
@@ -39,7 +42,7 @@ internal fun ColorSwatchSection(group: ColorSwatchGroup) {
             textStyle = LemonadeTheme.typography.headingXXSmall,
             modifier = Modifier.padding(horizontal = LemonadeTheme.spaces.spacing100),
         )
-        group.swatches.chunked(size = 2).forEach { row ->
+        group.swatches.chunked(size = COLUMNS).forEach { row ->
             Row(
                 horizontalArrangement = Arrangement.spacedBy(space = LemonadeTheme.spaces.spacing200),
             ) {
@@ -48,6 +51,9 @@ internal fun ColorSwatchSection(group: ColorSwatchGroup) {
                         swatch = swatch,
                         modifier = Modifier.weight(weight = 1f),
                     )
+                }
+                repeat(times = COLUMNS - row.size) {
+                    Spacer(modifier = Modifier.weight(weight = 1f))
                 }
             }
         }

--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/Displays.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/Displays.kt
@@ -18,6 +18,11 @@ internal interface Displays {
     }
 
     @Serializable
+    data object SemanticColors : Displays {
+        override val label: String = "Semantic Colors"
+    }
+
+    @Serializable
     data object ThemedColors : Displays {
         override val label: String = "Themed Colors"
     }

--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/HomeDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/HomeDisplay.kt
@@ -142,8 +142,8 @@ internal object DisplayRegistry {
             title = "Foundations",
             items = listOf(
                 Displays.Colors,
-                Displays.SemanticColors,
                 Displays.ThemedColors,
+                Displays.SemanticColors,
                 Displays.Spacing,
                 Displays.Radius,
                 Displays.Shadows,

--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/HomeDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/HomeDisplay.kt
@@ -142,6 +142,7 @@ internal object DisplayRegistry {
             title = "Foundations",
             items = listOf(
                 Displays.Colors,
+                Displays.SemanticColors,
                 Displays.ThemedColors,
                 Displays.Spacing,
                 Displays.Radius,

--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/SemanticColorsDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/SemanticColorsDisplay.kt
@@ -70,11 +70,13 @@ private fun semanticGroups(colors: LemonadeSemanticColors): List<SemanticGroup> 
         SemanticGroup(
             title = title,
             subgroups = subgroups.map { (subgroupTitle, tokens) ->
+                val path = subgroupTitle
+                    ?: title
                 SemanticSubgroup(
                     title = subgroupTitle,
                     swatches = tokens.map { (name, color) ->
                         ColorSwatch(
-                            path = title.lowercase(),
+                            path = path.lowercase(),
                             name = name,
                             fill = color,
                             label = labelColor(

--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/SemanticColorsDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/SemanticColorsDisplay.kt
@@ -1,0 +1,240 @@
+package com.teya.lemonade
+
+import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.compositeOver
+import androidx.compose.ui.graphics.luminance
+
+/** Where contrast against black overtakes contrast against white. */
+private const val DARK_LABEL_LUMINANCE_THRESHOLD = 0.179f
+
+@Composable
+internal fun SemanticColorsDisplay() {
+    val colors = LemonadeTheme.colors
+    val groups = remember(colors) { semanticGroups(colors = colors) }
+
+    SampleScreenDisplayLazyColumn(
+        title = "Semantic Colors",
+        background = colors.background.bgDefault,
+    ) {
+        items(
+            items = groups,
+            key = { group -> group.title },
+        ) { group ->
+            ColorSwatchSection(group = group)
+        }
+    }
+}
+
+private fun semanticGroups(colors: LemonadeSemanticColors): List<ColorSwatchGroup> =
+    listOf(
+        "Background" to backgroundTokens(colors = colors.background),
+        "Border" to borderTokens(colors = colors.border),
+        "Content" to contentTokens(colors = colors.content),
+        "Interaction" to interactionTokens(colors = colors.interaction),
+        "Scoped" to scopedTokens(colors = colors.scoped),
+        "Shadow" to shadowTokens(colors = colors.shadow),
+    ).map { (title, tokens) ->
+        ColorSwatchGroup(
+            title = title,
+            swatches = tokens.map { (name, color) ->
+                ColorSwatch(
+                    path = title.lowercase(),
+                    name = name,
+                    fill = color,
+                    label = labelColor(
+                        fill = color,
+                        colors = colors,
+                    ),
+                )
+            },
+        )
+    }
+
+/**
+ * The always-dark or always-light content token, whichever contrasts more with the swatch.
+ * Translucent tokens are drawn over the page, so contrast is measured on the composite.
+ */
+private fun labelColor(
+    fill: Color,
+    colors: LemonadeSemanticColors,
+): Color {
+    val luminance = fill
+        .compositeOver(colors.background.bgDefault)
+        .luminance()
+    return if (luminance > DARK_LABEL_LUMINANCE_THRESHOLD) {
+        colors.content.contentAlwaysDark
+    } else {
+        colors.content.contentAlwaysLight
+    }
+}
+
+private fun backgroundTokens(colors: LemonadeSemanticColors.BackgroundColors): List<Pair<String, Color>> =
+    listOf(
+        "bgBrand" to colors.bgBrand,
+        "bgBrandElevated" to colors.bgBrandElevated,
+        "bgBrandHigh" to colors.bgBrandHigh,
+        "bgBrandSubtle" to colors.bgBrandSubtle,
+        "bgAlwaysDark" to colors.bgAlwaysDark,
+        "bgAlwaysDarkHigh" to colors.bgAlwaysDarkHigh,
+        "bgAlwaysDarkLow" to colors.bgAlwaysDarkLow,
+        "bgAlwaysDarkMedium" to colors.bgAlwaysDarkMedium,
+        "bgAlwaysLight" to colors.bgAlwaysLight,
+        "bgAlwaysLightHigh" to colors.bgAlwaysLightHigh,
+        "bgAlwaysLightLow" to colors.bgAlwaysLightLow,
+        "bgAlwaysLightMedium" to colors.bgAlwaysLightMedium,
+        "bgDefaultInverse" to colors.bgDefaultInverse,
+        "bgElevatedInverse" to colors.bgElevatedInverse,
+        "bgSubtleInverse" to colors.bgSubtleInverse,
+        "bgCaution" to colors.bgCaution,
+        "bgCautionSubtle" to colors.bgCautionSubtle,
+        "bgCritical" to colors.bgCritical,
+        "bgCriticalSubtle" to colors.bgCriticalSubtle,
+        "bgFeatured" to colors.bgFeatured,
+        "bgFeaturedSubtle" to colors.bgFeaturedSubtle,
+        "bgInfo" to colors.bgInfo,
+        "bgInfoSubtle" to colors.bgInfoSubtle,
+        "bgNeutral" to colors.bgNeutral,
+        "bgNeutralSubtle" to colors.bgNeutralSubtle,
+        "bgPositive" to colors.bgPositive,
+        "bgPositiveSubtle" to colors.bgPositiveSubtle,
+        "bgDefault" to colors.bgDefault,
+        "bgElevated" to colors.bgElevated,
+        "bgElevatedHigh" to colors.bgElevatedHigh,
+        "bgSubtle" to colors.bgSubtle,
+    )
+
+private fun borderTokens(colors: LemonadeSemanticColors.BorderColors): List<Pair<String, Color>> =
+    listOf(
+        "borderBrand" to colors.borderBrand,
+        "borderOnBrandHigh" to colors.borderOnBrandHigh,
+        "borderOnBrandLow" to colors.borderOnBrandLow,
+        "borderOnBrandMedium" to colors.borderOnBrandMedium,
+        "borderAlwaysDark" to colors.borderAlwaysDark,
+        "borderAlwaysDarkHigh" to colors.borderAlwaysDarkHigh,
+        "borderAlwaysDarkLow" to colors.borderAlwaysDarkLow,
+        "borderAlwaysDarkMedium" to colors.borderAlwaysDarkMedium,
+        "borderAlwaysLight" to colors.borderAlwaysLight,
+        "borderAlwaysLightHigh" to colors.borderAlwaysLightHigh,
+        "borderAlwaysLightLow" to colors.borderAlwaysLightLow,
+        "borderAlwaysLightMedium" to colors.borderAlwaysLightMedium,
+        "borderBrandInverse" to colors.borderBrandInverse,
+        "borderNeutralHighInverse" to colors.borderNeutralHighInverse,
+        "borderNeutralLowInverse" to colors.borderNeutralLowInverse,
+        "borderNeutralMediumInverse" to colors.borderNeutralMediumInverse,
+        "borderSelectedInverse" to colors.borderSelectedInverse,
+        "borderCaution" to colors.borderCaution,
+        "borderCautionSubtle" to colors.borderCautionSubtle,
+        "borderCritical" to colors.borderCritical,
+        "borderCriticalSubtle" to colors.borderCriticalSubtle,
+        "borderFeatured" to colors.borderFeatured,
+        "borderFeaturedSubtle" to colors.borderFeaturedSubtle,
+        "borderInfo" to colors.borderInfo,
+        "borderInfoSubtle" to colors.borderInfoSubtle,
+        "borderPositive" to colors.borderPositive,
+        "borderPositiveSubtle" to colors.borderPositiveSubtle,
+        "borderNeutralHigh" to colors.borderNeutralHigh,
+        "borderNeutralLow" to colors.borderNeutralLow,
+        "borderNeutralMedium" to colors.borderNeutralMedium,
+        "borderSelected" to colors.borderSelected,
+    )
+
+private fun contentTokens(colors: LemonadeSemanticColors.ContentColors): List<Pair<String, Color>> =
+    listOf(
+        "contentBrand" to colors.contentBrand,
+        "contentBrandHigh" to colors.contentBrandHigh,
+        "contentOnBrandHigh" to colors.contentOnBrandHigh,
+        "contentOnBrandLow" to colors.contentOnBrandLow,
+        "contentAlwaysDark" to colors.contentAlwaysDark,
+        "contentAlwaysLight" to colors.contentAlwaysLight,
+        "contentCautionAlwaysOnColor" to colors.contentCautionAlwaysOnColor,
+        "contentCriticalAlwaysOnColor" to colors.contentCriticalAlwaysOnColor,
+        "contentInfoAlwaysOnColor" to colors.contentInfoAlwaysOnColor,
+        "contentNeutralAlwaysOnColor" to colors.contentNeutralAlwaysOnColor,
+        "contentPositiveAlwaysOnColor" to colors.contentPositiveAlwaysOnColor,
+        "contentBrandInverse" to colors.contentBrandInverse,
+        "contentPrimaryInverse" to colors.contentPrimaryInverse,
+        "contentSecondaryInverse" to colors.contentSecondaryInverse,
+        "contentTertiaryInverse" to colors.contentTertiaryInverse,
+        "contentCautionOnColor" to colors.contentCautionOnColor,
+        "contentCriticalOnColor" to colors.contentCriticalOnColor,
+        "contentFeaturedOnColor" to colors.contentFeaturedOnColor,
+        "contentInfoOnColor" to colors.contentInfoOnColor,
+        "contentNeutralOnColor" to colors.contentNeutralOnColor,
+        "contentPositiveOnColor" to colors.contentPositiveOnColor,
+        "contentCaution" to colors.contentCaution,
+        "contentCritical" to colors.contentCritical,
+        "contentFeatured" to colors.contentFeatured,
+        "contentInfo" to colors.contentInfo,
+        "contentNeutral" to colors.contentNeutral,
+        "contentPositive" to colors.contentPositive,
+        "contentPrimary" to colors.contentPrimary,
+        "contentSecondary" to colors.contentSecondary,
+        "contentTertiary" to colors.contentTertiary,
+    )
+
+private fun interactionTokens(colors: LemonadeSemanticColors.InteractionColors): List<Pair<String, Color>> =
+    listOf(
+        "bgAlwaysDarkHighInteractive" to colors.bgAlwaysDarkHighInteractive,
+        "bgAlwaysDarkLowInteractive" to colors.bgAlwaysDarkLowInteractive,
+        "bgAlwaysDarkMediumInteractive" to colors.bgAlwaysDarkMediumInteractive,
+        "bgAlwaysLightHighInteractive" to colors.bgAlwaysLightHighInteractive,
+        "bgAlwaysLightLowInteractive" to colors.bgAlwaysLightLowInteractive,
+        "bgAlwaysLightMediumInteractive" to colors.bgAlwaysLightMediumInteractive,
+        "bgBrandElevatedInteractive" to colors.bgBrandElevatedInteractive,
+        "bgBrandHighInteractive" to colors.bgBrandHighInteractive,
+        "bgBrandInteractive" to colors.bgBrandInteractive,
+        "bgCautionInteractive" to colors.bgCautionInteractive,
+        "bgCautionSubtleInteractive" to colors.bgCautionSubtleInteractive,
+        "bgCriticalInteractive" to colors.bgCriticalInteractive,
+        "bgCriticalSubtleInteractive" to colors.bgCriticalSubtleInteractive,
+        "bgDefaultInteractive" to colors.bgDefaultInteractive,
+        "bgElevatedHighInteractive" to colors.bgElevatedHighInteractive,
+        "bgElevatedInteractive" to colors.bgElevatedInteractive,
+        "bgFeaturedInteractive" to colors.bgFeaturedInteractive,
+        "bgFeaturedSubtleInteractive" to colors.bgFeaturedSubtleInteractive,
+        "bgInfoInteractive" to colors.bgInfoInteractive,
+        "bgInfoSubtleInteractive" to colors.bgInfoSubtleInteractive,
+        "bgNeutralInteractive" to colors.bgNeutralInteractive,
+        "bgNeutralSubtleInteractive" to colors.bgNeutralSubtleInteractive,
+        "bgPositiveInteractive" to colors.bgPositiveInteractive,
+        "bgPositiveSubtleInteractive" to colors.bgPositiveSubtleInteractive,
+        "bgSubtleInteractive" to colors.bgSubtleInteractive,
+        "bgBrandElevatedPressed" to colors.bgBrandElevatedPressed,
+        "bgBrandHighPressed" to colors.bgBrandHighPressed,
+        "bgBrandPressed" to colors.bgBrandPressed,
+        "bgCautionPressed" to colors.bgCautionPressed,
+        "bgCautionSubtlePressed" to colors.bgCautionSubtlePressed,
+        "bgCriticalPressed" to colors.bgCriticalPressed,
+        "bgCriticalSubtlePressed" to colors.bgCriticalSubtlePressed,
+        "bgDefaultPressed" to colors.bgDefaultPressed,
+        "bgElevatedPressed" to colors.bgElevatedPressed,
+        "bgFeaturedPressed" to colors.bgFeaturedPressed,
+        "bgFeaturedSubtlePressed" to colors.bgFeaturedSubtlePressed,
+        "bgInfoPressed" to colors.bgInfoPressed,
+        "bgInfoSubtlePressed" to colors.bgInfoSubtlePressed,
+        "bgNeutralPressed" to colors.bgNeutralPressed,
+        "bgNeutralSubtlePressed" to colors.bgNeutralSubtlePressed,
+        "bgPositivePressed" to colors.bgPositivePressed,
+        "bgPositiveSubtlePressed" to colors.bgPositiveSubtlePressed,
+        "bgSubtlePressed" to colors.bgSubtlePressed,
+    )
+
+private fun scopedTokens(colors: LemonadeSemanticColors.ScopedColors): List<Pair<String, Color>> =
+    listOf(
+        "bgSettlementBusinessDays" to colors.bgSettlementBusinessDays,
+        "bgSettlementEveryday" to colors.bgSettlementEveryday,
+        "bgSettlementInstant" to colors.bgSettlementInstant,
+        "bgSettlementScheduled" to colors.bgSettlementScheduled,
+        "contentOnSettlementBusinessDays" to colors.contentOnSettlementBusinessDays,
+        "contentOnSettlementEveryday" to colors.contentOnSettlementEveryday,
+        "contentOnSettlementInstant" to colors.contentOnSettlementInstant,
+        "contentOnSettlementScheduled" to colors.contentOnSettlementScheduled,
+    )
+
+private fun shadowTokens(colors: LemonadeSemanticColors.ShadowColors): List<Pair<String, Color>> =
+    listOf(
+        "shadowDefault" to colors.shadowDefault,
+    )

--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/SemanticColorsDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/SemanticColorsDisplay.kt
@@ -23,7 +23,10 @@ internal fun SemanticColorsDisplay() {
             items = groups,
             key = { group -> group.title },
         ) { group ->
-            ColorSwatchSection(group = group)
+            ColorSwatchSection(
+                group = group,
+                outlined = true,
+            )
         }
     }
 }

--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/SemanticColorsDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/SemanticColorsDisplay.kt
@@ -1,14 +1,28 @@
 package com.teya.lemonade
 
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.graphics.luminance
 
 /** Where contrast against black overtakes contrast against white. */
 private const val DARK_LABEL_LUMINANCE_THRESHOLD = 0.179f
+
+private typealias TokenSubgroups = List<Pair<String?, List<Pair<String, Color>>>>
+
+private data class SemanticGroup(
+    val title: String,
+    val subgroups: List<SemanticSubgroup>,
+)
+
+private data class SemanticSubgroup(
+    val title: String?,
+    val swatches: List<ColorSwatch>,
+)
 
 @Composable
 internal fun SemanticColorsDisplay() {
@@ -19,19 +33,32 @@ internal fun SemanticColorsDisplay() {
         title = "Semantic Colors",
         background = colors.background.bgDefault,
     ) {
-        items(
-            items = groups,
-            key = { group -> group.title },
-        ) { group ->
-            ColorSwatchSection(
-                group = group,
-                outlined = true,
-            )
+        groups.forEach { group ->
+            item(key = group.title) {
+                LemonadeUi.Text(
+                    text = group.title,
+                    textStyle = LemonadeTheme.typography.headingSmall,
+                    modifier = Modifier.padding(
+                        start = LemonadeTheme.spaces.spacing100,
+                        top = LemonadeTheme.spaces.spacing600,
+                    ),
+                )
+            }
+            items(
+                items = group.subgroups,
+                key = { subgroup -> "${group.title}/${subgroup.title}" },
+            ) { subgroup ->
+                ColorSwatchSection(
+                    title = subgroup.title,
+                    swatches = subgroup.swatches,
+                    outlined = true,
+                )
+            }
         }
     }
 }
 
-private fun semanticGroups(colors: LemonadeSemanticColors): List<ColorSwatchGroup> =
+private fun semanticGroups(colors: LemonadeSemanticColors): List<SemanticGroup> =
     listOf(
         "Background" to backgroundTokens(colors = colors.background),
         "Border" to borderTokens(colors = colors.border),
@@ -39,18 +66,23 @@ private fun semanticGroups(colors: LemonadeSemanticColors): List<ColorSwatchGrou
         "Interaction" to interactionTokens(colors = colors.interaction),
         "Scoped" to scopedTokens(colors = colors.scoped),
         "Shadow" to shadowTokens(colors = colors.shadow),
-    ).map { (title, tokens) ->
-        ColorSwatchGroup(
+    ).map { (title, subgroups) ->
+        SemanticGroup(
             title = title,
-            swatches = tokens.map { (name, color) ->
-                ColorSwatch(
-                    path = title.lowercase(),
-                    name = name,
-                    fill = color,
-                    label = labelColor(
-                        fill = color,
-                        colors = colors,
-                    ),
+            subgroups = subgroups.map { (subgroupTitle, tokens) ->
+                SemanticSubgroup(
+                    title = subgroupTitle,
+                    swatches = tokens.map { (name, color) ->
+                        ColorSwatch(
+                            path = title.lowercase(),
+                            name = name,
+                            fill = color,
+                            label = labelColor(
+                                fill = color,
+                                colors = colors,
+                            ),
+                        )
+                    },
                 )
             },
         )
@@ -74,170 +106,210 @@ private fun labelColor(
     }
 }
 
-private fun backgroundTokens(colors: LemonadeSemanticColors.BackgroundColors): List<Pair<String, Color>> =
+private fun backgroundTokens(colors: LemonadeSemanticColors.BackgroundColors): TokenSubgroups =
     listOf(
-        "bgBrand" to colors.bgBrand,
-        "bgBrandElevated" to colors.bgBrandElevated,
-        "bgBrandHigh" to colors.bgBrandHigh,
-        "bgBrandSubtle" to colors.bgBrandSubtle,
-        "bgAlwaysDark" to colors.bgAlwaysDark,
-        "bgAlwaysDarkHigh" to colors.bgAlwaysDarkHigh,
-        "bgAlwaysDarkLow" to colors.bgAlwaysDarkLow,
-        "bgAlwaysDarkMedium" to colors.bgAlwaysDarkMedium,
-        "bgAlwaysLight" to colors.bgAlwaysLight,
-        "bgAlwaysLightHigh" to colors.bgAlwaysLightHigh,
-        "bgAlwaysLightLow" to colors.bgAlwaysLightLow,
-        "bgAlwaysLightMedium" to colors.bgAlwaysLightMedium,
-        "bgDefaultInverse" to colors.bgDefaultInverse,
-        "bgElevatedInverse" to colors.bgElevatedInverse,
-        "bgSubtleInverse" to colors.bgSubtleInverse,
-        "bgCaution" to colors.bgCaution,
-        "bgCautionSubtle" to colors.bgCautionSubtle,
-        "bgCritical" to colors.bgCritical,
-        "bgCriticalSubtle" to colors.bgCriticalSubtle,
-        "bgFeatured" to colors.bgFeatured,
-        "bgFeaturedSubtle" to colors.bgFeaturedSubtle,
-        "bgInfo" to colors.bgInfo,
-        "bgInfoSubtle" to colors.bgInfoSubtle,
-        "bgNeutral" to colors.bgNeutral,
-        "bgNeutralSubtle" to colors.bgNeutralSubtle,
-        "bgPositive" to colors.bgPositive,
-        "bgPositiveSubtle" to colors.bgPositiveSubtle,
-        "bgDefault" to colors.bgDefault,
-        "bgElevated" to colors.bgElevated,
-        "bgElevatedHigh" to colors.bgElevatedHigh,
-        "bgSubtle" to colors.bgSubtle,
+        null to listOf(
+            "bgDefault" to colors.bgDefault,
+            "bgSubtle" to colors.bgSubtle,
+            "bgElevated" to colors.bgElevated,
+            "bgElevatedHigh" to colors.bgElevatedHigh,
+        ),
+        "Brand" to listOf(
+            "bgBrand" to colors.bgBrand,
+            "bgBrandElevated" to colors.bgBrandElevated,
+            "bgBrandSubtle" to colors.bgBrandSubtle,
+            "bgBrandHigh" to colors.bgBrandHigh,
+        ),
+        "Voice" to listOf(
+            "bgCritical" to colors.bgCritical,
+            "bgCaution" to colors.bgCaution,
+            "bgInfo" to colors.bgInfo,
+            "bgPositive" to colors.bgPositive,
+            "bgFeatured" to colors.bgFeatured,
+            "bgNeutral" to colors.bgNeutral,
+            "bgCriticalSubtle" to colors.bgCriticalSubtle,
+            "bgCautionSubtle" to colors.bgCautionSubtle,
+            "bgInfoSubtle" to colors.bgInfoSubtle,
+            "bgPositiveSubtle" to colors.bgPositiveSubtle,
+            "bgFeaturedSubtle" to colors.bgFeaturedSubtle,
+            "bgNeutralSubtle" to colors.bgNeutralSubtle,
+        ),
+        "Inverse" to listOf(
+            "bgDefaultInverse" to colors.bgDefaultInverse,
+            "bgSubtleInverse" to colors.bgSubtleInverse,
+            "bgElevatedInverse" to colors.bgElevatedInverse,
+        ),
+        "Fixed" to listOf(
+            "bgAlwaysDark" to colors.bgAlwaysDark,
+            "bgAlwaysDarkHigh" to colors.bgAlwaysDarkHigh,
+            "bgAlwaysDarkMedium" to colors.bgAlwaysDarkMedium,
+            "bgAlwaysDarkLow" to colors.bgAlwaysDarkLow,
+            "bgAlwaysLight" to colors.bgAlwaysLight,
+            "bgAlwaysLightHigh" to colors.bgAlwaysLightHigh,
+            "bgAlwaysLightMedium" to colors.bgAlwaysLightMedium,
+            "bgAlwaysLightLow" to colors.bgAlwaysLightLow,
+        ),
     )
 
-private fun borderTokens(colors: LemonadeSemanticColors.BorderColors): List<Pair<String, Color>> =
+private fun borderTokens(colors: LemonadeSemanticColors.BorderColors): TokenSubgroups =
     listOf(
-        "borderBrand" to colors.borderBrand,
-        "borderOnBrandHigh" to colors.borderOnBrandHigh,
-        "borderOnBrandLow" to colors.borderOnBrandLow,
-        "borderOnBrandMedium" to colors.borderOnBrandMedium,
-        "borderAlwaysDark" to colors.borderAlwaysDark,
-        "borderAlwaysDarkHigh" to colors.borderAlwaysDarkHigh,
-        "borderAlwaysDarkLow" to colors.borderAlwaysDarkLow,
-        "borderAlwaysDarkMedium" to colors.borderAlwaysDarkMedium,
-        "borderAlwaysLight" to colors.borderAlwaysLight,
-        "borderAlwaysLightHigh" to colors.borderAlwaysLightHigh,
-        "borderAlwaysLightLow" to colors.borderAlwaysLightLow,
-        "borderAlwaysLightMedium" to colors.borderAlwaysLightMedium,
-        "borderBrandInverse" to colors.borderBrandInverse,
-        "borderNeutralHighInverse" to colors.borderNeutralHighInverse,
-        "borderNeutralLowInverse" to colors.borderNeutralLowInverse,
-        "borderNeutralMediumInverse" to colors.borderNeutralMediumInverse,
-        "borderSelectedInverse" to colors.borderSelectedInverse,
-        "borderCaution" to colors.borderCaution,
-        "borderCautionSubtle" to colors.borderCautionSubtle,
-        "borderCritical" to colors.borderCritical,
-        "borderCriticalSubtle" to colors.borderCriticalSubtle,
-        "borderFeatured" to colors.borderFeatured,
-        "borderFeaturedSubtle" to colors.borderFeaturedSubtle,
-        "borderInfo" to colors.borderInfo,
-        "borderInfoSubtle" to colors.borderInfoSubtle,
-        "borderPositive" to colors.borderPositive,
-        "borderPositiveSubtle" to colors.borderPositiveSubtle,
-        "borderNeutralHigh" to colors.borderNeutralHigh,
-        "borderNeutralLow" to colors.borderNeutralLow,
-        "borderNeutralMedium" to colors.borderNeutralMedium,
-        "borderSelected" to colors.borderSelected,
+        null to listOf(
+            "borderNeutralLow" to colors.borderNeutralLow,
+            "borderNeutralMedium" to colors.borderNeutralMedium,
+            "borderNeutralHigh" to colors.borderNeutralHigh,
+            "borderSelected" to colors.borderSelected,
+        ),
+        "Brand" to listOf(
+            "borderBrand" to colors.borderBrand,
+            "borderOnBrandLow" to colors.borderOnBrandLow,
+            "borderOnBrandMedium" to colors.borderOnBrandMedium,
+            "borderOnBrandHigh" to colors.borderOnBrandHigh,
+        ),
+        "Voice" to listOf(
+            "borderCritical" to colors.borderCritical,
+            "borderCaution" to colors.borderCaution,
+            "borderInfo" to colors.borderInfo,
+            "borderPositive" to colors.borderPositive,
+            "borderFeatured" to colors.borderFeatured,
+            "borderCriticalSubtle" to colors.borderCriticalSubtle,
+            "borderCautionSubtle" to colors.borderCautionSubtle,
+            "borderInfoSubtle" to colors.borderInfoSubtle,
+            "borderPositiveSubtle" to colors.borderPositiveSubtle,
+            "borderFeaturedSubtle" to colors.borderFeaturedSubtle,
+        ),
+        "Inverse" to listOf(
+            "borderNeutralLowInverse" to colors.borderNeutralLowInverse,
+            "borderNeutralMediumInverse" to colors.borderNeutralMediumInverse,
+            "borderNeutralHighInverse" to colors.borderNeutralHighInverse,
+            "borderSelectedInverse" to colors.borderSelectedInverse,
+            "borderBrandInverse" to colors.borderBrandInverse,
+        ),
+        "Fixed" to listOf(
+            "borderAlwaysLight" to colors.borderAlwaysLight,
+            "borderAlwaysLightLow" to colors.borderAlwaysLightLow,
+            "borderAlwaysLightMedium" to colors.borderAlwaysLightMedium,
+            "borderAlwaysLightHigh" to colors.borderAlwaysLightHigh,
+            "borderAlwaysDark" to colors.borderAlwaysDark,
+            "borderAlwaysDarkLow" to colors.borderAlwaysDarkLow,
+            "borderAlwaysDarkMedium" to colors.borderAlwaysDarkMedium,
+            "borderAlwaysDarkHigh" to colors.borderAlwaysDarkHigh,
+        ),
     )
 
-private fun contentTokens(colors: LemonadeSemanticColors.ContentColors): List<Pair<String, Color>> =
+private fun contentTokens(colors: LemonadeSemanticColors.ContentColors): TokenSubgroups =
     listOf(
-        "contentBrand" to colors.contentBrand,
-        "contentBrandHigh" to colors.contentBrandHigh,
-        "contentOnBrandHigh" to colors.contentOnBrandHigh,
-        "contentOnBrandLow" to colors.contentOnBrandLow,
-        "contentAlwaysDark" to colors.contentAlwaysDark,
-        "contentAlwaysLight" to colors.contentAlwaysLight,
-        "contentCautionAlwaysOnColor" to colors.contentCautionAlwaysOnColor,
-        "contentCriticalAlwaysOnColor" to colors.contentCriticalAlwaysOnColor,
-        "contentInfoAlwaysOnColor" to colors.contentInfoAlwaysOnColor,
-        "contentNeutralAlwaysOnColor" to colors.contentNeutralAlwaysOnColor,
-        "contentPositiveAlwaysOnColor" to colors.contentPositiveAlwaysOnColor,
-        "contentBrandInverse" to colors.contentBrandInverse,
-        "contentPrimaryInverse" to colors.contentPrimaryInverse,
-        "contentSecondaryInverse" to colors.contentSecondaryInverse,
-        "contentTertiaryInverse" to colors.contentTertiaryInverse,
-        "contentCautionOnColor" to colors.contentCautionOnColor,
-        "contentCriticalOnColor" to colors.contentCriticalOnColor,
-        "contentFeaturedOnColor" to colors.contentFeaturedOnColor,
-        "contentInfoOnColor" to colors.contentInfoOnColor,
-        "contentNeutralOnColor" to colors.contentNeutralOnColor,
-        "contentPositiveOnColor" to colors.contentPositiveOnColor,
-        "contentCaution" to colors.contentCaution,
-        "contentCritical" to colors.contentCritical,
-        "contentFeatured" to colors.contentFeatured,
-        "contentInfo" to colors.contentInfo,
-        "contentNeutral" to colors.contentNeutral,
-        "contentPositive" to colors.contentPositive,
-        "contentPrimary" to colors.contentPrimary,
-        "contentSecondary" to colors.contentSecondary,
-        "contentTertiary" to colors.contentTertiary,
+        null to listOf(
+            "contentPrimary" to colors.contentPrimary,
+            "contentSecondary" to colors.contentSecondary,
+            "contentTertiary" to colors.contentTertiary,
+        ),
+        "Brand" to listOf(
+            "contentBrand" to colors.contentBrand,
+            "contentBrandHigh" to colors.contentBrandHigh,
+            "contentOnBrandHigh" to colors.contentOnBrandHigh,
+            "contentOnBrandLow" to colors.contentOnBrandLow,
+        ),
+        "Voice" to listOf(
+            "contentCritical" to colors.contentCritical,
+            "contentCaution" to colors.contentCaution,
+            "contentInfo" to colors.contentInfo,
+            "contentPositive" to colors.contentPositive,
+            "contentFeatured" to colors.contentFeatured,
+            "contentNeutral" to colors.contentNeutral,
+        ),
+        "Voice / On Color" to listOf(
+            "contentCriticalOnColor" to colors.contentCriticalOnColor,
+            "contentCautionOnColor" to colors.contentCautionOnColor,
+            "contentInfoOnColor" to colors.contentInfoOnColor,
+            "contentPositiveOnColor" to colors.contentPositiveOnColor,
+            "contentFeaturedOnColor" to colors.contentFeaturedOnColor,
+            "contentNeutralOnColor" to colors.contentNeutralOnColor,
+        ),
+        "Inverse" to listOf(
+            "contentPrimaryInverse" to colors.contentPrimaryInverse,
+            "contentSecondaryInverse" to colors.contentSecondaryInverse,
+            "contentTertiaryInverse" to colors.contentTertiaryInverse,
+            "contentBrandInverse" to colors.contentBrandInverse,
+        ),
+        "Fixed" to listOf(
+            "contentAlwaysLight" to colors.contentAlwaysLight,
+            "contentAlwaysDark" to colors.contentAlwaysDark,
+            "contentCriticalAlwaysOnColor" to colors.contentCriticalAlwaysOnColor,
+            "contentCautionAlwaysOnColor" to colors.contentCautionAlwaysOnColor,
+            "contentInfoAlwaysOnColor" to colors.contentInfoAlwaysOnColor,
+            "contentPositiveAlwaysOnColor" to colors.contentPositiveAlwaysOnColor,
+            "contentNeutralAlwaysOnColor" to colors.contentNeutralAlwaysOnColor,
+        ),
     )
 
-private fun interactionTokens(colors: LemonadeSemanticColors.InteractionColors): List<Pair<String, Color>> =
+private fun interactionTokens(colors: LemonadeSemanticColors.InteractionColors): TokenSubgroups =
     listOf(
-        "bgAlwaysDarkHighInteractive" to colors.bgAlwaysDarkHighInteractive,
-        "bgAlwaysDarkLowInteractive" to colors.bgAlwaysDarkLowInteractive,
-        "bgAlwaysDarkMediumInteractive" to colors.bgAlwaysDarkMediumInteractive,
-        "bgAlwaysLightHighInteractive" to colors.bgAlwaysLightHighInteractive,
-        "bgAlwaysLightLowInteractive" to colors.bgAlwaysLightLowInteractive,
-        "bgAlwaysLightMediumInteractive" to colors.bgAlwaysLightMediumInteractive,
-        "bgBrandElevatedInteractive" to colors.bgBrandElevatedInteractive,
-        "bgBrandHighInteractive" to colors.bgBrandHighInteractive,
-        "bgBrandInteractive" to colors.bgBrandInteractive,
-        "bgCautionInteractive" to colors.bgCautionInteractive,
-        "bgCautionSubtleInteractive" to colors.bgCautionSubtleInteractive,
-        "bgCriticalInteractive" to colors.bgCriticalInteractive,
-        "bgCriticalSubtleInteractive" to colors.bgCriticalSubtleInteractive,
-        "bgDefaultInteractive" to colors.bgDefaultInteractive,
-        "bgElevatedHighInteractive" to colors.bgElevatedHighInteractive,
-        "bgElevatedInteractive" to colors.bgElevatedInteractive,
-        "bgFeaturedInteractive" to colors.bgFeaturedInteractive,
-        "bgFeaturedSubtleInteractive" to colors.bgFeaturedSubtleInteractive,
-        "bgInfoInteractive" to colors.bgInfoInteractive,
-        "bgInfoSubtleInteractive" to colors.bgInfoSubtleInteractive,
-        "bgNeutralInteractive" to colors.bgNeutralInteractive,
-        "bgNeutralSubtleInteractive" to colors.bgNeutralSubtleInteractive,
-        "bgPositiveInteractive" to colors.bgPositiveInteractive,
-        "bgPositiveSubtleInteractive" to colors.bgPositiveSubtleInteractive,
-        "bgSubtleInteractive" to colors.bgSubtleInteractive,
-        "bgBrandElevatedPressed" to colors.bgBrandElevatedPressed,
-        "bgBrandHighPressed" to colors.bgBrandHighPressed,
-        "bgBrandPressed" to colors.bgBrandPressed,
-        "bgCautionPressed" to colors.bgCautionPressed,
-        "bgCautionSubtlePressed" to colors.bgCautionSubtlePressed,
-        "bgCriticalPressed" to colors.bgCriticalPressed,
-        "bgCriticalSubtlePressed" to colors.bgCriticalSubtlePressed,
-        "bgDefaultPressed" to colors.bgDefaultPressed,
-        "bgElevatedPressed" to colors.bgElevatedPressed,
-        "bgFeaturedPressed" to colors.bgFeaturedPressed,
-        "bgFeaturedSubtlePressed" to colors.bgFeaturedSubtlePressed,
-        "bgInfoPressed" to colors.bgInfoPressed,
-        "bgInfoSubtlePressed" to colors.bgInfoSubtlePressed,
-        "bgNeutralPressed" to colors.bgNeutralPressed,
-        "bgNeutralSubtlePressed" to colors.bgNeutralSubtlePressed,
-        "bgPositivePressed" to colors.bgPositivePressed,
-        "bgPositiveSubtlePressed" to colors.bgPositiveSubtlePressed,
-        "bgSubtlePressed" to colors.bgSubtlePressed,
+        "Interactive / Background" to listOf(
+            "bgDefaultInteractive" to colors.bgDefaultInteractive,
+            "bgSubtleInteractive" to colors.bgSubtleInteractive,
+            "bgElevatedInteractive" to colors.bgElevatedInteractive,
+            "bgElevatedHighInteractive" to colors.bgElevatedHighInteractive,
+            "bgBrandInteractive" to colors.bgBrandInteractive,
+            "bgBrandElevatedInteractive" to colors.bgBrandElevatedInteractive,
+            "bgBrandHighInteractive" to colors.bgBrandHighInteractive,
+            "bgCriticalInteractive" to colors.bgCriticalInteractive,
+            "bgCautionInteractive" to colors.bgCautionInteractive,
+            "bgInfoInteractive" to colors.bgInfoInteractive,
+            "bgPositiveInteractive" to colors.bgPositiveInteractive,
+            "bgFeaturedInteractive" to colors.bgFeaturedInteractive,
+            "bgNeutralInteractive" to colors.bgNeutralInteractive,
+            "bgCriticalSubtleInteractive" to colors.bgCriticalSubtleInteractive,
+            "bgCautionSubtleInteractive" to colors.bgCautionSubtleInteractive,
+            "bgInfoSubtleInteractive" to colors.bgInfoSubtleInteractive,
+            "bgPositiveSubtleInteractive" to colors.bgPositiveSubtleInteractive,
+            "bgFeaturedSubtleInteractive" to colors.bgFeaturedSubtleInteractive,
+            "bgNeutralSubtleInteractive" to colors.bgNeutralSubtleInteractive,
+            "bgAlwaysDarkHighInteractive" to colors.bgAlwaysDarkHighInteractive,
+            "bgAlwaysDarkMediumInteractive" to colors.bgAlwaysDarkMediumInteractive,
+            "bgAlwaysDarkLowInteractive" to colors.bgAlwaysDarkLowInteractive,
+            "bgAlwaysLightHighInteractive" to colors.bgAlwaysLightHighInteractive,
+            "bgAlwaysLightMediumInteractive" to colors.bgAlwaysLightMediumInteractive,
+            "bgAlwaysLightLowInteractive" to colors.bgAlwaysLightLowInteractive,
+        ),
+        "Pressed / Background" to listOf(
+            "bgDefaultPressed" to colors.bgDefaultPressed,
+            "bgSubtlePressed" to colors.bgSubtlePressed,
+            "bgElevatedPressed" to colors.bgElevatedPressed,
+            "bgBrandPressed" to colors.bgBrandPressed,
+            "bgBrandElevatedPressed" to colors.bgBrandElevatedPressed,
+            "bgBrandHighPressed" to colors.bgBrandHighPressed,
+            "bgCriticalPressed" to colors.bgCriticalPressed,
+            "bgCautionPressed" to colors.bgCautionPressed,
+            "bgInfoPressed" to colors.bgInfoPressed,
+            "bgPositivePressed" to colors.bgPositivePressed,
+            "bgFeaturedPressed" to colors.bgFeaturedPressed,
+            "bgNeutralPressed" to colors.bgNeutralPressed,
+            "bgCriticalSubtlePressed" to colors.bgCriticalSubtlePressed,
+            "bgCautionSubtlePressed" to colors.bgCautionSubtlePressed,
+            "bgInfoSubtlePressed" to colors.bgInfoSubtlePressed,
+            "bgPositiveSubtlePressed" to colors.bgPositiveSubtlePressed,
+            "bgFeaturedSubtlePressed" to colors.bgFeaturedSubtlePressed,
+            "bgNeutralSubtlePressed" to colors.bgNeutralSubtlePressed,
+        ),
     )
 
-private fun scopedTokens(colors: LemonadeSemanticColors.ScopedColors): List<Pair<String, Color>> =
+private fun scopedTokens(colors: LemonadeSemanticColors.ScopedColors): TokenSubgroups =
     listOf(
-        "bgSettlementBusinessDays" to colors.bgSettlementBusinessDays,
-        "bgSettlementEveryday" to colors.bgSettlementEveryday,
-        "bgSettlementInstant" to colors.bgSettlementInstant,
-        "bgSettlementScheduled" to colors.bgSettlementScheduled,
-        "contentOnSettlementBusinessDays" to colors.contentOnSettlementBusinessDays,
-        "contentOnSettlementEveryday" to colors.contentOnSettlementEveryday,
-        "contentOnSettlementInstant" to colors.contentOnSettlementInstant,
-        "contentOnSettlementScheduled" to colors.contentOnSettlementScheduled,
+        "Settlements" to listOf(
+            "bgSettlementInstant" to colors.bgSettlementInstant,
+            "bgSettlementBusinessDays" to colors.bgSettlementBusinessDays,
+            "bgSettlementEveryday" to colors.bgSettlementEveryday,
+            "bgSettlementScheduled" to colors.bgSettlementScheduled,
+            "contentOnSettlementInstant" to colors.contentOnSettlementInstant,
+            "contentOnSettlementBusinessDays" to colors.contentOnSettlementBusinessDays,
+            "contentOnSettlementEveryday" to colors.contentOnSettlementEveryday,
+            "contentOnSettlementScheduled" to colors.contentOnSettlementScheduled,
+        ),
     )
 
-private fun shadowTokens(colors: LemonadeSemanticColors.ShadowColors): List<Pair<String, Color>> =
+private fun shadowTokens(colors: LemonadeSemanticColors.ShadowColors): TokenSubgroups =
     listOf(
-        "shadowDefault" to colors.shadowDefault,
+        null to listOf(
+            "shadowDefault" to colors.shadowDefault,
+        ),
     )

--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/SemanticColorsDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/SemanticColorsDisplay.kt
@@ -12,16 +12,11 @@ import androidx.compose.ui.graphics.luminance
 /** Where contrast against black overtakes contrast against white. */
 private const val DARK_LABEL_LUMINANCE_THRESHOLD = 0.179f
 
-private typealias TokenSubgroups = List<Pair<String?, List<Pair<String, Color>>>>
+private typealias TokenSubgroups = Map<String?, Map<String, Color>>
 
 private data class SemanticGroup(
     val title: String,
-    val subgroups: List<SemanticSubgroup>,
-)
-
-private data class SemanticSubgroup(
-    val title: String?,
-    val swatches: List<ColorSwatch>,
+    val subgroups: List<ColorSwatchGroup>,
 )
 
 @Composable
@@ -46,11 +41,10 @@ internal fun SemanticColorsDisplay() {
             }
             items(
                 items = group.subgroups,
-                key = { subgroup -> "${group.title}/${subgroup.title}" },
+                key = { subgroup -> subgroup.id },
             ) { subgroup ->
                 ColorSwatchSection(
-                    title = subgroup.title,
-                    swatches = subgroup.swatches,
+                    group = subgroup,
                     outlined = true,
                 )
             }
@@ -71,12 +65,14 @@ private fun semanticGroups(colors: LemonadeSemanticColors): List<SemanticGroup> 
             title = title,
             subgroups = subgroups.map { (subgroupTitle, tokens) ->
                 val path = subgroupTitle
-                    ?: title
-                SemanticSubgroup(
+                    ?.lowercase()
+                    ?: title.lowercase()
+                ColorSwatchGroup(
+                    id = "$title/$subgroupTitle",
                     title = subgroupTitle,
                     swatches = tokens.map { (name, color) ->
                         ColorSwatch(
-                            path = path.lowercase(),
+                            path = path,
                             name = name,
                             fill = color,
                             label = labelColor(
@@ -109,20 +105,20 @@ private fun labelColor(
 }
 
 private fun backgroundTokens(colors: LemonadeSemanticColors.BackgroundColors): TokenSubgroups =
-    listOf(
-        null to listOf(
+    mapOf(
+        null to mapOf(
             "bgDefault" to colors.bgDefault,
             "bgSubtle" to colors.bgSubtle,
             "bgElevated" to colors.bgElevated,
             "bgElevatedHigh" to colors.bgElevatedHigh,
         ),
-        "Brand" to listOf(
+        "Brand" to mapOf(
             "bgBrand" to colors.bgBrand,
             "bgBrandElevated" to colors.bgBrandElevated,
             "bgBrandSubtle" to colors.bgBrandSubtle,
             "bgBrandHigh" to colors.bgBrandHigh,
         ),
-        "Voice" to listOf(
+        "Voice" to mapOf(
             "bgCritical" to colors.bgCritical,
             "bgCaution" to colors.bgCaution,
             "bgInfo" to colors.bgInfo,
@@ -136,12 +132,12 @@ private fun backgroundTokens(colors: LemonadeSemanticColors.BackgroundColors): T
             "bgFeaturedSubtle" to colors.bgFeaturedSubtle,
             "bgNeutralSubtle" to colors.bgNeutralSubtle,
         ),
-        "Inverse" to listOf(
+        "Inverse" to mapOf(
             "bgDefaultInverse" to colors.bgDefaultInverse,
             "bgSubtleInverse" to colors.bgSubtleInverse,
             "bgElevatedInverse" to colors.bgElevatedInverse,
         ),
-        "Fixed" to listOf(
+        "Fixed" to mapOf(
             "bgAlwaysDark" to colors.bgAlwaysDark,
             "bgAlwaysDarkHigh" to colors.bgAlwaysDarkHigh,
             "bgAlwaysDarkMedium" to colors.bgAlwaysDarkMedium,
@@ -154,20 +150,20 @@ private fun backgroundTokens(colors: LemonadeSemanticColors.BackgroundColors): T
     )
 
 private fun borderTokens(colors: LemonadeSemanticColors.BorderColors): TokenSubgroups =
-    listOf(
-        null to listOf(
+    mapOf(
+        null to mapOf(
             "borderNeutralLow" to colors.borderNeutralLow,
             "borderNeutralMedium" to colors.borderNeutralMedium,
             "borderNeutralHigh" to colors.borderNeutralHigh,
             "borderSelected" to colors.borderSelected,
         ),
-        "Brand" to listOf(
+        "Brand" to mapOf(
             "borderBrand" to colors.borderBrand,
             "borderOnBrandLow" to colors.borderOnBrandLow,
             "borderOnBrandMedium" to colors.borderOnBrandMedium,
             "borderOnBrandHigh" to colors.borderOnBrandHigh,
         ),
-        "Voice" to listOf(
+        "Voice" to mapOf(
             "borderCritical" to colors.borderCritical,
             "borderCaution" to colors.borderCaution,
             "borderInfo" to colors.borderInfo,
@@ -179,14 +175,14 @@ private fun borderTokens(colors: LemonadeSemanticColors.BorderColors): TokenSubg
             "borderPositiveSubtle" to colors.borderPositiveSubtle,
             "borderFeaturedSubtle" to colors.borderFeaturedSubtle,
         ),
-        "Inverse" to listOf(
+        "Inverse" to mapOf(
             "borderNeutralLowInverse" to colors.borderNeutralLowInverse,
             "borderNeutralMediumInverse" to colors.borderNeutralMediumInverse,
             "borderNeutralHighInverse" to colors.borderNeutralHighInverse,
             "borderSelectedInverse" to colors.borderSelectedInverse,
             "borderBrandInverse" to colors.borderBrandInverse,
         ),
-        "Fixed" to listOf(
+        "Fixed" to mapOf(
             "borderAlwaysLight" to colors.borderAlwaysLight,
             "borderAlwaysLightLow" to colors.borderAlwaysLightLow,
             "borderAlwaysLightMedium" to colors.borderAlwaysLightMedium,
@@ -199,19 +195,19 @@ private fun borderTokens(colors: LemonadeSemanticColors.BorderColors): TokenSubg
     )
 
 private fun contentTokens(colors: LemonadeSemanticColors.ContentColors): TokenSubgroups =
-    listOf(
-        null to listOf(
+    mapOf(
+        null to mapOf(
             "contentPrimary" to colors.contentPrimary,
             "contentSecondary" to colors.contentSecondary,
             "contentTertiary" to colors.contentTertiary,
         ),
-        "Brand" to listOf(
+        "Brand" to mapOf(
             "contentBrand" to colors.contentBrand,
             "contentBrandHigh" to colors.contentBrandHigh,
             "contentOnBrandHigh" to colors.contentOnBrandHigh,
             "contentOnBrandLow" to colors.contentOnBrandLow,
         ),
-        "Voice" to listOf(
+        "Voice" to mapOf(
             "contentCritical" to colors.contentCritical,
             "contentCaution" to colors.contentCaution,
             "contentInfo" to colors.contentInfo,
@@ -219,7 +215,7 @@ private fun contentTokens(colors: LemonadeSemanticColors.ContentColors): TokenSu
             "contentFeatured" to colors.contentFeatured,
             "contentNeutral" to colors.contentNeutral,
         ),
-        "Voice / On Color" to listOf(
+        "Voice / On Color" to mapOf(
             "contentCriticalOnColor" to colors.contentCriticalOnColor,
             "contentCautionOnColor" to colors.contentCautionOnColor,
             "contentInfoOnColor" to colors.contentInfoOnColor,
@@ -227,13 +223,13 @@ private fun contentTokens(colors: LemonadeSemanticColors.ContentColors): TokenSu
             "contentFeaturedOnColor" to colors.contentFeaturedOnColor,
             "contentNeutralOnColor" to colors.contentNeutralOnColor,
         ),
-        "Inverse" to listOf(
+        "Inverse" to mapOf(
             "contentPrimaryInverse" to colors.contentPrimaryInverse,
             "contentSecondaryInverse" to colors.contentSecondaryInverse,
             "contentTertiaryInverse" to colors.contentTertiaryInverse,
             "contentBrandInverse" to colors.contentBrandInverse,
         ),
-        "Fixed" to listOf(
+        "Fixed" to mapOf(
             "contentAlwaysLight" to colors.contentAlwaysLight,
             "contentAlwaysDark" to colors.contentAlwaysDark,
             "contentCriticalAlwaysOnColor" to colors.contentCriticalAlwaysOnColor,
@@ -245,8 +241,8 @@ private fun contentTokens(colors: LemonadeSemanticColors.ContentColors): TokenSu
     )
 
 private fun interactionTokens(colors: LemonadeSemanticColors.InteractionColors): TokenSubgroups =
-    listOf(
-        "Interactive / Background" to listOf(
+    mapOf(
+        "Interactive / Background" to mapOf(
             "bgDefaultInteractive" to colors.bgDefaultInteractive,
             "bgSubtleInteractive" to colors.bgSubtleInteractive,
             "bgElevatedInteractive" to colors.bgElevatedInteractive,
@@ -273,7 +269,7 @@ private fun interactionTokens(colors: LemonadeSemanticColors.InteractionColors):
             "bgAlwaysLightMediumInteractive" to colors.bgAlwaysLightMediumInteractive,
             "bgAlwaysLightLowInteractive" to colors.bgAlwaysLightLowInteractive,
         ),
-        "Pressed / Background" to listOf(
+        "Pressed / Background" to mapOf(
             "bgDefaultPressed" to colors.bgDefaultPressed,
             "bgSubtlePressed" to colors.bgSubtlePressed,
             "bgElevatedPressed" to colors.bgElevatedPressed,
@@ -296,8 +292,8 @@ private fun interactionTokens(colors: LemonadeSemanticColors.InteractionColors):
     )
 
 private fun scopedTokens(colors: LemonadeSemanticColors.ScopedColors): TokenSubgroups =
-    listOf(
-        "Settlements" to listOf(
+    mapOf(
+        "Settlements" to mapOf(
             "bgSettlementInstant" to colors.bgSettlementInstant,
             "bgSettlementBusinessDays" to colors.bgSettlementBusinessDays,
             "bgSettlementEveryday" to colors.bgSettlementEveryday,
@@ -310,8 +306,8 @@ private fun scopedTokens(colors: LemonadeSemanticColors.ScopedColors): TokenSubg
     )
 
 private fun shadowTokens(colors: LemonadeSemanticColors.ShadowColors): TokenSubgroups =
-    listOf(
-        null to listOf(
+    mapOf(
+        null to mapOf(
             "shadowDefault" to colors.shadowDefault,
         ),
     )

--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ThemedColorsDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ThemedColorsDisplay.kt
@@ -2,21 +2,9 @@
 
 package com.teya.lemonade
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
-
-private val SwatchHeight: Dp = 162.dp
 
 private val UppercaseLetter = Regex(pattern = "[A-Z]")
 
@@ -33,82 +21,12 @@ internal fun ThemedColorsDisplay() {
             items = hues,
             key = { hue -> hue.title },
         ) { hue ->
-            ThemedHueSection(hue = hue)
+            ColorSwatchSection(group = hue)
         }
     }
 }
 
-@Composable
-private fun ThemedHueSection(hue: ThemedHue) {
-    Column(
-        verticalArrangement = Arrangement.spacedBy(space = LemonadeTheme.spaces.spacing200),
-        modifier = Modifier.padding(vertical = LemonadeTheme.spaces.spacing400),
-    ) {
-        LemonadeUi.Text(
-            text = hue.title,
-            textStyle = LemonadeTheme.typography.headingXXSmall,
-            modifier = Modifier.padding(horizontal = LemonadeTheme.spaces.spacing100),
-        )
-        hue.swatches
-            .chunked(size = 2)
-            .forEach { row ->
-                Row(
-                    horizontalArrangement = Arrangement.spacedBy(space = LemonadeTheme.spaces.spacing200),
-                ) {
-                    row.forEach { swatch ->
-                        ThemedSwatchBlock(
-                            swatch = swatch,
-                            modifier = Modifier.weight(weight = 1f),
-                        )
-                    }
-                }
-            }
-    }
-}
-
-@Composable
-private fun ThemedSwatchBlock(
-    swatch: ThemedSwatch,
-    modifier: Modifier = Modifier,
-) {
-    Column(
-        verticalArrangement = Arrangement.SpaceBetween,
-        modifier = modifier
-            .height(height = SwatchHeight)
-            .background(
-                color = swatch.fill,
-                shape = LemonadeTheme.shapes.radius600,
-            ).padding(
-                horizontal = LemonadeTheme.spaces.spacing400,
-                vertical = LemonadeTheme.spaces.spacing500,
-            ),
-    ) {
-        LemonadeUi.Text(
-            text = swatch.path,
-            textStyle = LemonadeTheme.typography.bodyXSmallRegular,
-            color = swatch.label.copy(alpha = swatch.label.alpha * LemonadeTheme.opacities.base.opacity70),
-        )
-        LemonadeUi.Text(
-            text = swatch.slot,
-            textStyle = LemonadeTheme.typography.bodyXSmallMedium,
-            color = swatch.label,
-        )
-    }
-}
-
-private data class ThemedSwatch(
-    val path: String,
-    val slot: String,
-    val fill: Color,
-    val label: Color,
-)
-
-private data class ThemedHue(
-    val title: String,
-    val swatches: List<ThemedSwatch>,
-)
-
-private fun themedHues(themed: LemonadeThemedColors): List<ThemedHue> =
+private fun themedHues(themed: LemonadeThemedColors): List<ColorSwatchGroup> =
     listOf(
         "amber" to themed.amber,
         "blue" to themed.blue,
@@ -128,7 +46,7 @@ private fun themedHues(themed: LemonadeThemedColors): List<ThemedHue> =
         "yellow" to themed.yellow,
         "yellowLime" to themed.yellowLime,
     ).map { (name, color) ->
-        ThemedHue(
+        ColorSwatchGroup(
             title = name
                 .replace(
                     regex = UppercaseLetter,
@@ -147,47 +65,47 @@ private fun themedHues(themed: LemonadeThemedColors): List<ThemedHue> =
 private fun primarySwatches(
     name: String,
     color: ThemedPrimaryColor,
-): List<ThemedSwatch> =
+): List<ColorSwatch> =
     listOf(
-        ThemedSwatch(
+        ColorSwatch(
             path = name,
-            slot = "background",
+            name = "background",
             fill = color.background,
             label = color.onBackground,
         ),
-        ThemedSwatch(
+        ColorSwatch(
             path = name,
-            slot = "border",
+            name = "border",
             fill = color.border,
             label = color.onBackground,
         ),
-        ThemedSwatch(
+        ColorSwatch(
             path = name,
-            slot = "content",
+            name = "content",
             fill = color.content,
             label = color.contentInverse,
         ),
-        ThemedSwatch(
+        ColorSwatch(
             path = name,
-            slot = "contentInverse",
+            name = "contentInverse",
             fill = color.contentInverse,
             label = color.onBackground,
         ),
-        ThemedSwatch(
+        ColorSwatch(
             path = name,
-            slot = "onBackground",
+            name = "onBackground",
             fill = color.onBackground,
             label = color.content,
         ),
-        ThemedSwatch(
+        ColorSwatch(
             path = name,
-            slot = "backgroundHigh",
+            name = "backgroundHigh",
             fill = color.backgroundHigh,
             label = color.contentInverse,
         ),
-        ThemedSwatch(
+        ColorSwatch(
             path = name,
-            slot = "onBackgroundHigh",
+            name = "onBackgroundHigh",
             fill = color.onBackgroundHigh,
             label = color.content,
         ),
@@ -196,23 +114,23 @@ private fun primarySwatches(
 private fun subtleSwatches(
     name: String,
     color: ThemedPrimaryColor,
-): List<ThemedSwatch> =
+): List<ColorSwatch> =
     listOf(
-        ThemedSwatch(
+        ColorSwatch(
             path = "$name.subtle",
-            slot = "background",
+            name = "background",
             fill = color.subtle.background,
             label = color.subtle.onBackground,
         ),
-        ThemedSwatch(
+        ColorSwatch(
             path = "$name.subtle",
-            slot = "border",
+            name = "border",
             fill = color.subtle.border,
             label = color.subtle.onBackground,
         ),
-        ThemedSwatch(
+        ColorSwatch(
             path = "$name.subtle",
-            slot = "onBackground",
+            name = "onBackground",
             fill = color.subtle.onBackground,
             label = color.contentInverse,
         ),

--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ThemedColorsDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ThemedColorsDisplay.kt
@@ -21,7 +21,10 @@ internal fun ThemedColorsDisplay() {
             items = hues,
             key = { hue -> hue.title },
         ) { hue ->
-            ColorSwatchSection(group = hue)
+            ColorSwatchSection(
+                title = hue.title,
+                swatches = hue.swatches,
+            )
         }
     }
 }

--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ThemedColorsDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ThemedColorsDisplay.kt
@@ -19,12 +19,9 @@ internal fun ThemedColorsDisplay() {
     ) {
         items(
             items = hues,
-            key = { hue -> hue.title },
+            key = { hue -> hue.id },
         ) { hue ->
-            ColorSwatchSection(
-                title = hue.title,
-                swatches = hue.swatches,
-            )
+            ColorSwatchSection(group = hue)
         }
     }
 }
@@ -50,6 +47,7 @@ private fun themedHues(themed: LemonadeThemedColors): List<ColorSwatchGroup> =
         "yellowLime" to themed.yellowLime,
     ).map { (name, color) ->
         ColorSwatchGroup(
+            id = name,
             title = name
                 .replace(
                     regex = UppercaseLetter,

--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/app/App.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/app/App.kt
@@ -34,6 +34,7 @@ import com.teya.lemonade.SearchFieldDisplay
 import com.teya.lemonade.SegmentedControlDisplay
 import com.teya.lemonade.SelectFieldDisplay
 import com.teya.lemonade.SelectListItemDisplay
+import com.teya.lemonade.SemanticColorsDisplay
 import com.teya.lemonade.ShadowDisplay
 import com.teya.lemonade.SizesDisplay
 import com.teya.lemonade.SkeletonDisplay
@@ -60,6 +61,7 @@ internal expect val platformScreens: Map<Displays, @Composable (onNavigate: (Dis
 internal val screens: Map<Displays, @Composable (onNavigate: (Displays) -> Unit) -> Unit> = platformScreens + mapOf(
     Displays.Home to { onNavigate -> HomeDisplay(onNavigate = onNavigate) },
     Displays.Colors to { _ -> ColorsDisplay() },
+    Displays.SemanticColors to { _ -> SemanticColorsDisplay() },
     Displays.ThemedColors to { _ -> ThemedColorsDisplay() },
     Displays.Icons to { _ -> IconsDisplay() },
     Displays.CountryFlag to { _ -> CountryFlagDisplay() },

--- a/swiftui/SampleApp/ColorSwatchSection.swift
+++ b/swiftui/SampleApp/ColorSwatchSection.swift
@@ -17,6 +17,7 @@ struct ColorSwatchGroup: Identifiable {
 
 struct ColorSwatchSection: View {
     let group: ColorSwatchGroup
+    var outlined: Bool = false
 
     private let columns = [
         GridItem(.flexible(), spacing: LemonadeTheme.spaces.spacing200),
@@ -33,7 +34,7 @@ struct ColorSwatchSection: View {
 
             LazyVGrid(columns: columns, spacing: LemonadeTheme.spaces.spacing200) {
                 ForEach(group.swatches) { swatch in
-                    ColorSwatchView(swatch: swatch)
+                    ColorSwatchView(swatch: swatch, outlined: outlined)
                 }
             }
         }
@@ -43,6 +44,7 @@ struct ColorSwatchSection: View {
 
 private struct ColorSwatchView: View {
     let swatch: ColorSwatch
+    let outlined: Bool
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -67,5 +69,11 @@ private struct ColorSwatchView: View {
         .frame(height: 162)
         .background(swatch.fill)
         .clipShape(RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius600))
+        .overlay {
+            if outlined {
+                RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius600)
+                    .strokeBorder(.border.borderNeutralLow, lineWidth: LemonadeTheme.borderWidth.base.border25)
+            }
+        }
     }
 }

--- a/swiftui/SampleApp/ColorSwatchSection.swift
+++ b/swiftui/SampleApp/ColorSwatchSection.swift
@@ -50,18 +50,13 @@ private struct ColorSwatchView: View {
     let swatch: ColorSwatch
     let outlined: Bool
 
-    private var shape: RoundedRectangle {
-        RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius600)
-    }
-
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             LemonadeUi.Text(
                 swatch.path,
                 textStyle: LemonadeTypography.shared.bodyXSmallRegular,
-                color: swatch.label
+                color: swatch.label.opacity(LemonadeTheme.opacity.base.opacity70)
             )
-            .opacity(LemonadeTheme.opacity.base.opacity70)
 
             Spacer(minLength: 0)
 
@@ -75,10 +70,10 @@ private struct ColorSwatchView: View {
         .padding(.horizontal, LemonadeTheme.spaces.spacing400)
         .padding(.vertical, LemonadeTheme.spaces.spacing500)
         .frame(height: 162)
-        .background(swatch.fill, in: shape)
+        .background(swatch.fill, in: LemonadeTheme.shapes.radius600)
         .overlay {
             if outlined {
-                shape.strokeBorder(.border.borderNeutralLow, lineWidth: LemonadeTheme.borderWidth.base.border25)
+                LemonadeTheme.shapes.radius600.strokeBorder(.border.borderNeutralLow, lineWidth: LemonadeTheme.borderWidth.base.border25)
             }
         }
     }

--- a/swiftui/SampleApp/ColorSwatchSection.swift
+++ b/swiftui/SampleApp/ColorSwatchSection.swift
@@ -9,25 +9,26 @@ struct ColorSwatch: Identifiable {
     let label: Color
 }
 
+/// Titles repeat across a page (every semantic group has a "Brand"), and a lazy stack
+/// flattens nested `ForEach`es into one list, so the id must be unique page-wide.
 struct ColorSwatchGroup: Identifiable {
-    var id: String { title }
-    let title: String
+    let id: String
+    let title: String?
     let swatches: [ColorSwatch]
 }
 
 struct ColorSwatchSection: View {
-    let title: String?
-    let swatches: [ColorSwatch]
+    let group: ColorSwatchGroup
     var outlined: Bool = false
 
-    private let columns = [
-        GridItem(.flexible(), spacing: LemonadeTheme.spaces.spacing200),
-        GridItem(.flexible(), spacing: LemonadeTheme.spaces.spacing200),
-    ]
+    private let columns = Array(
+        repeating: GridItem(.flexible(), spacing: LemonadeTheme.spaces.spacing200),
+        count: 2
+    )
 
     var body: some View {
         VStack(alignment: .leading, spacing: LemonadeTheme.spaces.spacing200) {
-            if let title {
+            if let title = group.title {
                 LemonadeUi.Text(
                     title,
                     textStyle: LemonadeTypography.shared.headingXXSmall
@@ -36,7 +37,7 @@ struct ColorSwatchSection: View {
             }
 
             LazyVGrid(columns: columns, spacing: LemonadeTheme.spaces.spacing200) {
-                ForEach(swatches) { swatch in
+                ForEach(group.swatches) { swatch in
                     ColorSwatchView(swatch: swatch, outlined: outlined)
                 }
             }
@@ -48,6 +49,10 @@ struct ColorSwatchSection: View {
 private struct ColorSwatchView: View {
     let swatch: ColorSwatch
     let outlined: Bool
+
+    private var shape: RoundedRectangle {
+        RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius600)
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -70,12 +75,10 @@ private struct ColorSwatchView: View {
         .padding(.horizontal, LemonadeTheme.spaces.spacing400)
         .padding(.vertical, LemonadeTheme.spaces.spacing500)
         .frame(height: 162)
-        .background(swatch.fill)
-        .clipShape(RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius600))
+        .background(swatch.fill, in: shape)
         .overlay {
             if outlined {
-                RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius600)
-                    .strokeBorder(.border.borderNeutralLow, lineWidth: LemonadeTheme.borderWidth.base.border25)
+                shape.strokeBorder(.border.borderNeutralLow, lineWidth: LemonadeTheme.borderWidth.base.border25)
             }
         }
     }

--- a/swiftui/SampleApp/ColorSwatchSection.swift
+++ b/swiftui/SampleApp/ColorSwatchSection.swift
@@ -1,0 +1,71 @@
+import SwiftUI
+import Lemonade
+
+struct ColorSwatch: Identifiable {
+    var id: String { "\(path).\(name)" }
+    let path: String
+    let name: String
+    let fill: Color
+    let label: Color
+}
+
+struct ColorSwatchGroup: Identifiable {
+    var id: String { title }
+    let title: String
+    let swatches: [ColorSwatch]
+}
+
+struct ColorSwatchSection: View {
+    let group: ColorSwatchGroup
+
+    private let columns = [
+        GridItem(.flexible(), spacing: LemonadeTheme.spaces.spacing200),
+        GridItem(.flexible(), spacing: LemonadeTheme.spaces.spacing200),
+    ]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: LemonadeTheme.spaces.spacing200) {
+            LemonadeUi.Text(
+                group.title,
+                textStyle: LemonadeTypography.shared.headingXXSmall
+            )
+            .padding(.horizontal, LemonadeTheme.spaces.spacing100)
+
+            LazyVGrid(columns: columns, spacing: LemonadeTheme.spaces.spacing200) {
+                ForEach(group.swatches) { swatch in
+                    ColorSwatchView(swatch: swatch)
+                }
+            }
+        }
+        .padding(LemonadeTheme.spaces.spacing400)
+    }
+}
+
+private struct ColorSwatchView: View {
+    let swatch: ColorSwatch
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            LemonadeUi.Text(
+                swatch.path,
+                textStyle: LemonadeTypography.shared.bodyXSmallRegular,
+                color: swatch.label
+            )
+            .opacity(LemonadeTheme.opacity.base.opacity70)
+
+            Spacer(minLength: 0)
+
+            LemonadeUi.Text(
+                swatch.name,
+                textStyle: LemonadeTypography.shared.bodyXSmallMedium,
+                color: swatch.label
+            )
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+        .padding(.horizontal, LemonadeTheme.spaces.spacing400)
+        .padding(.vertical, LemonadeTheme.spaces.spacing500)
+        .frame(height: 162)
+        .background(swatch.fill)
+        .clipShape(RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius600))
+    }
+}

--- a/swiftui/SampleApp/ColorSwatchSection.swift
+++ b/swiftui/SampleApp/ColorSwatchSection.swift
@@ -16,7 +16,8 @@ struct ColorSwatchGroup: Identifiable {
 }
 
 struct ColorSwatchSection: View {
-    let group: ColorSwatchGroup
+    let title: String?
+    let swatches: [ColorSwatch]
     var outlined: Bool = false
 
     private let columns = [
@@ -26,14 +27,16 @@ struct ColorSwatchSection: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: LemonadeTheme.spaces.spacing200) {
-            LemonadeUi.Text(
-                group.title,
-                textStyle: LemonadeTypography.shared.headingXXSmall
-            )
-            .padding(.horizontal, LemonadeTheme.spaces.spacing100)
+            if let title {
+                LemonadeUi.Text(
+                    title,
+                    textStyle: LemonadeTypography.shared.headingXXSmall
+                )
+                .padding(.horizontal, LemonadeTheme.spaces.spacing100)
+            }
 
             LazyVGrid(columns: columns, spacing: LemonadeTheme.spaces.spacing200) {
-                ForEach(group.swatches) { swatch in
+                ForEach(swatches) { swatch in
                     ColorSwatchView(swatch: swatch, outlined: outlined)
                 }
             }

--- a/swiftui/SampleApp/ColorsDisplayView.swift
+++ b/swiftui/SampleApp/ColorsDisplayView.swift
@@ -42,10 +42,11 @@ struct ColorsDisplayView: View {
         SemanticGroup(
             title: title,
             subgroups: subgroups.map { subgroup in
-                SemanticSubgroup(
+                let path = (subgroup.title ?? title).lowercased()
+                return SemanticSubgroup(
                     title: subgroup.title,
                     swatches: subgroup.tokens.map { name, color in
-                        ColorSwatch(path: title.lowercased(), name: name, fill: color, label: labelColor(for: color))
+                        ColorSwatch(path: path, name: name, fill: color, label: labelColor(for: color))
                     }
                 )
             }

--- a/swiftui/SampleApp/ColorsDisplayView.swift
+++ b/swiftui/SampleApp/ColorsDisplayView.swift
@@ -44,6 +44,7 @@ struct ColorsDisplayView: View {
             subgroups: subgroups.map { subgroup in
                 let path = (subgroup.title ?? title).lowercased()
                 return SemanticSubgroup(
+                    id: "\(title)/\(subgroup.title ?? "")",
                     title: subgroup.title,
                     swatches: subgroup.tokens.map { name, color in
                         ColorSwatch(path: path, name: name, fill: color, label: labelColor(for: color))
@@ -101,8 +102,10 @@ private struct SemanticGroup: Identifiable {
     let subgroups: [SemanticSubgroup]
 }
 
+/// Sub-group titles repeat across groups, and the lazy stack flattens every group's
+/// sub-groups into one list, so the id has to carry the group too.
 private struct SemanticSubgroup: Identifiable {
-    var id: String { title ?? "" }
+    let id: String
     let title: String?
     let swatches: [ColorSwatch]
 }

--- a/swiftui/SampleApp/ColorsDisplayView.swift
+++ b/swiftui/SampleApp/ColorsDisplayView.swift
@@ -9,7 +9,16 @@ struct ColorsDisplayView: View {
         ScrollView {
             LazyVStack(alignment: .leading, spacing: 0) {
                 ForEach(semanticGroups) { group in
-                    ColorSwatchSection(group: group, outlined: true)
+                    LemonadeUi.Text(
+                        group.title,
+                        textStyle: LemonadeTypography.shared.headingSmall
+                    )
+                    .padding(.horizontal, LemonadeTheme.spaces.spacing500)
+                    .padding(.top, LemonadeTheme.spaces.spacing600)
+
+                    ForEach(group.subgroups) { subgroup in
+                        ColorSwatchSection(title: subgroup.title, swatches: subgroup.swatches, outlined: true)
+                    }
                 }
             }
         }
@@ -17,23 +26,28 @@ struct ColorsDisplayView: View {
         .navigationTitle("Semantic Colors")
     }
 
-    private var semanticGroups: [ColorSwatchGroup] {
+    private var semanticGroups: [SemanticGroup] {
         let colors = LemonadeTheme.colors
         return [
-            group(title: "Background", tokens: backgroundTokens(colors.background)),
-            group(title: "Border", tokens: borderTokens(colors.border)),
-            group(title: "Content", tokens: contentTokens(colors.content)),
-            group(title: "Interaction", tokens: interactionTokens(colors.interaction)),
-            group(title: "Scoped", tokens: scopedTokens(colors.scoped)),
-            group(title: "Shadow", tokens: shadowTokens(colors.shadow)),
+            group(title: "Background", subgroups: backgroundTokens(colors.background)),
+            group(title: "Border", subgroups: borderTokens(colors.border)),
+            group(title: "Content", subgroups: contentTokens(colors.content)),
+            group(title: "Interaction", subgroups: interactionTokens(colors.interaction)),
+            group(title: "Scoped", subgroups: scopedTokens(colors.scoped)),
+            group(title: "Shadow", subgroups: shadowTokens(colors.shadow)),
         ]
     }
 
-    private func group(title: String, tokens: [(String, Color)]) -> ColorSwatchGroup {
-        ColorSwatchGroup(
+    private func group(title: String, subgroups: [TokenSubgroup]) -> SemanticGroup {
+        SemanticGroup(
             title: title,
-            swatches: tokens.map { name, color in
-                ColorSwatch(path: title.lowercased(), name: name, fill: color, label: labelColor(for: color))
+            subgroups: subgroups.map { subgroup in
+                SemanticSubgroup(
+                    title: subgroup.title,
+                    swatches: subgroup.tokens.map { name, color in
+                        ColorSwatch(path: title.lowercased(), name: name, fill: color, label: labelColor(for: color))
+                    }
+                )
             }
         )
     }
@@ -80,180 +94,235 @@ struct ColorsDisplayView: View {
 
 // MARK: - Semantic Color Data
 
-private func backgroundTokens(_ colors: BackgroundColors) -> [(String, Color)] {
+private struct SemanticGroup: Identifiable {
+    var id: String { title }
+    let title: String
+    let subgroups: [SemanticSubgroup]
+}
+
+private struct SemanticSubgroup: Identifiable {
+    var id: String { title ?? "" }
+    let title: String?
+    let swatches: [ColorSwatch]
+}
+
+private typealias TokenSubgroup = (title: String?, tokens: [(String, Color)])
+
+
+private func backgroundTokens(_ colors: BackgroundColors) -> [TokenSubgroup] {
     [
-        ("bgBrand", colors.bgBrand),
-        ("bgBrandElevated", colors.bgBrandElevated),
-        ("bgBrandHigh", colors.bgBrandHigh),
-        ("bgBrandSubtle", colors.bgBrandSubtle),
-        ("bgAlwaysDark", colors.bgAlwaysDark),
-        ("bgAlwaysDarkHigh", colors.bgAlwaysDarkHigh),
-        ("bgAlwaysDarkLow", colors.bgAlwaysDarkLow),
-        ("bgAlwaysDarkMedium", colors.bgAlwaysDarkMedium),
-        ("bgAlwaysLight", colors.bgAlwaysLight),
-        ("bgAlwaysLightHigh", colors.bgAlwaysLightHigh),
-        ("bgAlwaysLightLow", colors.bgAlwaysLightLow),
-        ("bgAlwaysLightMedium", colors.bgAlwaysLightMedium),
-        ("bgTransparent", colors.bgTransparent),
-        ("bgTransparentDark", colors.bgTransparentDark),
-        ("bgTransparentLight", colors.bgTransparentLight),
-        ("bgDefaultInverse", colors.bgDefaultInverse),
-        ("bgElevatedInverse", colors.bgElevatedInverse),
-        ("bgSubtleInverse", colors.bgSubtleInverse),
-        ("bgCaution", colors.bgCaution),
-        ("bgCautionSubtle", colors.bgCautionSubtle),
-        ("bgCritical", colors.bgCritical),
-        ("bgCriticalSubtle", colors.bgCriticalSubtle),
-        ("bgFeatured", colors.bgFeatured),
-        ("bgFeaturedSubtle", colors.bgFeaturedSubtle),
-        ("bgInfo", colors.bgInfo),
-        ("bgInfoSubtle", colors.bgInfoSubtle),
-        ("bgNeutral", colors.bgNeutral),
-        ("bgNeutralSubtle", colors.bgNeutralSubtle),
-        ("bgPositive", colors.bgPositive),
-        ("bgPositiveSubtle", colors.bgPositiveSubtle),
-        ("bgDefault", colors.bgDefault),
-        ("bgElevated", colors.bgElevated),
-        ("bgElevatedHigh", colors.bgElevatedHigh),
-        ("bgSubtle", colors.bgSubtle),
+        (nil, [
+            ("bgDefault", colors.bgDefault),
+            ("bgSubtle", colors.bgSubtle),
+            ("bgElevated", colors.bgElevated),
+            ("bgElevatedHigh", colors.bgElevatedHigh),
+        ]),
+        ("Brand", [
+            ("bgBrand", colors.bgBrand),
+            ("bgBrandElevated", colors.bgBrandElevated),
+            ("bgBrandSubtle", colors.bgBrandSubtle),
+            ("bgBrandHigh", colors.bgBrandHigh),
+        ]),
+        ("Voice", [
+            ("bgCritical", colors.bgCritical),
+            ("bgCaution", colors.bgCaution),
+            ("bgInfo", colors.bgInfo),
+            ("bgPositive", colors.bgPositive),
+            ("bgFeatured", colors.bgFeatured),
+            ("bgNeutral", colors.bgNeutral),
+            ("bgCriticalSubtle", colors.bgCriticalSubtle),
+            ("bgCautionSubtle", colors.bgCautionSubtle),
+            ("bgInfoSubtle", colors.bgInfoSubtle),
+            ("bgPositiveSubtle", colors.bgPositiveSubtle),
+            ("bgFeaturedSubtle", colors.bgFeaturedSubtle),
+            ("bgNeutralSubtle", colors.bgNeutralSubtle),
+        ]),
+        ("Inverse", [
+            ("bgDefaultInverse", colors.bgDefaultInverse),
+            ("bgSubtleInverse", colors.bgSubtleInverse),
+            ("bgElevatedInverse", colors.bgElevatedInverse),
+        ]),
+        ("Fixed", [
+            ("bgAlwaysDark", colors.bgAlwaysDark),
+            ("bgAlwaysDarkHigh", colors.bgAlwaysDarkHigh),
+            ("bgAlwaysDarkMedium", colors.bgAlwaysDarkMedium),
+            ("bgAlwaysDarkLow", colors.bgAlwaysDarkLow),
+            ("bgAlwaysLight", colors.bgAlwaysLight),
+            ("bgAlwaysLightHigh", colors.bgAlwaysLightHigh),
+            ("bgAlwaysLightMedium", colors.bgAlwaysLightMedium),
+            ("bgAlwaysLightLow", colors.bgAlwaysLightLow),
+            ("bgTransparent", colors.bgTransparent),
+            ("bgTransparentLight", colors.bgTransparentLight),
+            ("bgTransparentDark", colors.bgTransparentDark),
+        ]),
     ]
 }
 
-private func borderTokens(_ colors: BorderColors) -> [(String, Color)] {
+private func borderTokens(_ colors: BorderColors) -> [TokenSubgroup] {
     [
-        ("borderBrand", colors.borderBrand),
-        ("borderOnBrandHigh", colors.borderOnBrandHigh),
-        ("borderOnBrandLow", colors.borderOnBrandLow),
-        ("borderOnBrandMedium", colors.borderOnBrandMedium),
-        ("borderAlwaysDark", colors.borderAlwaysDark),
-        ("borderAlwaysDarkHigh", colors.borderAlwaysDarkHigh),
-        ("borderAlwaysDarkLow", colors.borderAlwaysDarkLow),
-        ("borderAlwaysDarkMedium", colors.borderAlwaysDarkMedium),
-        ("borderAlwaysLight", colors.borderAlwaysLight),
-        ("borderAlwaysLightHigh", colors.borderAlwaysLightHigh),
-        ("borderAlwaysLightLow", colors.borderAlwaysLightLow),
-        ("borderAlwaysLightMedium", colors.borderAlwaysLightMedium),
-        ("borderBrandInverse", colors.borderBrandInverse),
-        ("borderNeutralHighInverse", colors.borderNeutralHighInverse),
-        ("borderNeutralLowInverse", colors.borderNeutralLowInverse),
-        ("borderNeutralMediumInverse", colors.borderNeutralMediumInverse),
-        ("borderSelectedInverse", colors.borderSelectedInverse),
-        ("borderCaution", colors.borderCaution),
-        ("borderCautionSubtle", colors.borderCautionSubtle),
-        ("borderCritical", colors.borderCritical),
-        ("borderCriticalSubtle", colors.borderCriticalSubtle),
-        ("borderFeatured", colors.borderFeatured),
-        ("borderFeaturedSubtle", colors.borderFeaturedSubtle),
-        ("borderInfo", colors.borderInfo),
-        ("borderInfoSubtle", colors.borderInfoSubtle),
-        ("borderPositive", colors.borderPositive),
-        ("borderPositiveSubtle", colors.borderPositiveSubtle),
-        ("borderNeutralHigh", colors.borderNeutralHigh),
-        ("borderNeutralLow", colors.borderNeutralLow),
-        ("borderNeutralMedium", colors.borderNeutralMedium),
-        ("borderSelected", colors.borderSelected),
+        (nil, [
+            ("borderNeutralLow", colors.borderNeutralLow),
+            ("borderNeutralMedium", colors.borderNeutralMedium),
+            ("borderNeutralHigh", colors.borderNeutralHigh),
+            ("borderSelected", colors.borderSelected),
+        ]),
+        ("Brand", [
+            ("borderBrand", colors.borderBrand),
+            ("borderOnBrandLow", colors.borderOnBrandLow),
+            ("borderOnBrandMedium", colors.borderOnBrandMedium),
+            ("borderOnBrandHigh", colors.borderOnBrandHigh),
+        ]),
+        ("Voice", [
+            ("borderCritical", colors.borderCritical),
+            ("borderCaution", colors.borderCaution),
+            ("borderInfo", colors.borderInfo),
+            ("borderPositive", colors.borderPositive),
+            ("borderFeatured", colors.borderFeatured),
+            ("borderCriticalSubtle", colors.borderCriticalSubtle),
+            ("borderCautionSubtle", colors.borderCautionSubtle),
+            ("borderInfoSubtle", colors.borderInfoSubtle),
+            ("borderPositiveSubtle", colors.borderPositiveSubtle),
+            ("borderFeaturedSubtle", colors.borderFeaturedSubtle),
+        ]),
+        ("Inverse", [
+            ("borderNeutralLowInverse", colors.borderNeutralLowInverse),
+            ("borderNeutralMediumInverse", colors.borderNeutralMediumInverse),
+            ("borderNeutralHighInverse", colors.borderNeutralHighInverse),
+            ("borderSelectedInverse", colors.borderSelectedInverse),
+            ("borderBrandInverse", colors.borderBrandInverse),
+        ]),
+        ("Fixed", [
+            ("borderAlwaysLight", colors.borderAlwaysLight),
+            ("borderAlwaysLightLow", colors.borderAlwaysLightLow),
+            ("borderAlwaysLightMedium", colors.borderAlwaysLightMedium),
+            ("borderAlwaysLightHigh", colors.borderAlwaysLightHigh),
+            ("borderAlwaysDark", colors.borderAlwaysDark),
+            ("borderAlwaysDarkLow", colors.borderAlwaysDarkLow),
+            ("borderAlwaysDarkMedium", colors.borderAlwaysDarkMedium),
+            ("borderAlwaysDarkHigh", colors.borderAlwaysDarkHigh),
+        ]),
     ]
 }
 
-private func contentTokens(_ colors: ContentColors) -> [(String, Color)] {
+private func contentTokens(_ colors: ContentColors) -> [TokenSubgroup] {
     [
-        ("contentBrand", colors.contentBrand),
-        ("contentBrandHigh", colors.contentBrandHigh),
-        ("contentOnBrandHigh", colors.contentOnBrandHigh),
-        ("contentOnBrandLow", colors.contentOnBrandLow),
-        ("contentAlwaysDark", colors.contentAlwaysDark),
-        ("contentAlwaysLight", colors.contentAlwaysLight),
-        ("contentCautionAlwaysOnColor", colors.contentCautionAlwaysOnColor),
-        ("contentCriticalAlwaysOnColor", colors.contentCriticalAlwaysOnColor),
-        ("contentInfoAlwaysOnColor", colors.contentInfoAlwaysOnColor),
-        ("contentNeutralAlwaysOnColor", colors.contentNeutralAlwaysOnColor),
-        ("contentPositiveAlwaysOnColor", colors.contentPositiveAlwaysOnColor),
-        ("contentBrandInverse", colors.contentBrandInverse),
-        ("contentPrimaryInverse", colors.contentPrimaryInverse),
-        ("contentSecondaryInverse", colors.contentSecondaryInverse),
-        ("contentTertiaryInverse", colors.contentTertiaryInverse),
-        ("contentCautionOnColor", colors.contentCautionOnColor),
-        ("contentCriticalOnColor", colors.contentCriticalOnColor),
-        ("contentFeaturedOnColor", colors.contentFeaturedOnColor),
-        ("contentInfoOnColor", colors.contentInfoOnColor),
-        ("contentNeutralOnColor", colors.contentNeutralOnColor),
-        ("contentPositiveOnColor", colors.contentPositiveOnColor),
-        ("contentCaution", colors.contentCaution),
-        ("contentCritical", colors.contentCritical),
-        ("contentFeatured", colors.contentFeatured),
-        ("contentInfo", colors.contentInfo),
-        ("contentNeutral", colors.contentNeutral),
-        ("contentPositive", colors.contentPositive),
-        ("contentPrimary", colors.contentPrimary),
-        ("contentSecondary", colors.contentSecondary),
-        ("contentTertiary", colors.contentTertiary),
+        (nil, [
+            ("contentPrimary", colors.contentPrimary),
+            ("contentSecondary", colors.contentSecondary),
+            ("contentTertiary", colors.contentTertiary),
+        ]),
+        ("Brand", [
+            ("contentBrand", colors.contentBrand),
+            ("contentBrandHigh", colors.contentBrandHigh),
+            ("contentOnBrandHigh", colors.contentOnBrandHigh),
+            ("contentOnBrandLow", colors.contentOnBrandLow),
+        ]),
+        ("Voice", [
+            ("contentCritical", colors.contentCritical),
+            ("contentCaution", colors.contentCaution),
+            ("contentInfo", colors.contentInfo),
+            ("contentPositive", colors.contentPositive),
+            ("contentFeatured", colors.contentFeatured),
+            ("contentNeutral", colors.contentNeutral),
+        ]),
+        ("Voice / On Color", [
+            ("contentCriticalOnColor", colors.contentCriticalOnColor),
+            ("contentCautionOnColor", colors.contentCautionOnColor),
+            ("contentInfoOnColor", colors.contentInfoOnColor),
+            ("contentPositiveOnColor", colors.contentPositiveOnColor),
+            ("contentFeaturedOnColor", colors.contentFeaturedOnColor),
+            ("contentNeutralOnColor", colors.contentNeutralOnColor),
+        ]),
+        ("Inverse", [
+            ("contentPrimaryInverse", colors.contentPrimaryInverse),
+            ("contentSecondaryInverse", colors.contentSecondaryInverse),
+            ("contentTertiaryInverse", colors.contentTertiaryInverse),
+            ("contentBrandInverse", colors.contentBrandInverse),
+        ]),
+        ("Fixed", [
+            ("contentAlwaysLight", colors.contentAlwaysLight),
+            ("contentAlwaysDark", colors.contentAlwaysDark),
+            ("contentCriticalAlwaysOnColor", colors.contentCriticalAlwaysOnColor),
+            ("contentCautionAlwaysOnColor", colors.contentCautionAlwaysOnColor),
+            ("contentInfoAlwaysOnColor", colors.contentInfoAlwaysOnColor),
+            ("contentPositiveAlwaysOnColor", colors.contentPositiveAlwaysOnColor),
+            ("contentNeutralAlwaysOnColor", colors.contentNeutralAlwaysOnColor),
+        ]),
     ]
 }
 
-private func interactionTokens(_ colors: InteractionColors) -> [(String, Color)] {
+private func interactionTokens(_ colors: InteractionColors) -> [TokenSubgroup] {
     [
-        ("bgAlwaysDarkHighInteractive", colors.bgAlwaysDarkHighInteractive),
-        ("bgAlwaysDarkLowInteractive", colors.bgAlwaysDarkLowInteractive),
-        ("bgAlwaysDarkMediumInteractive", colors.bgAlwaysDarkMediumInteractive),
-        ("bgAlwaysLightHighInteractive", colors.bgAlwaysLightHighInteractive),
-        ("bgAlwaysLightLowInteractive", colors.bgAlwaysLightLowInteractive),
-        ("bgAlwaysLightMediumInteractive", colors.bgAlwaysLightMediumInteractive),
-        ("bgBrandElevatedInteractive", colors.bgBrandElevatedInteractive),
-        ("bgBrandHighInteractive", colors.bgBrandHighInteractive),
-        ("bgBrandInteractive", colors.bgBrandInteractive),
-        ("bgCautionInteractive", colors.bgCautionInteractive),
-        ("bgCautionSubtleInteractive", colors.bgCautionSubtleInteractive),
-        ("bgCriticalInteractive", colors.bgCriticalInteractive),
-        ("bgCriticalSubtleInteractive", colors.bgCriticalSubtleInteractive),
-        ("bgDefaultInteractive", colors.bgDefaultInteractive),
-        ("bgElevatedHighInteractive", colors.bgElevatedHighInteractive),
-        ("bgElevatedInteractive", colors.bgElevatedInteractive),
-        ("bgFeaturedInteractive", colors.bgFeaturedInteractive),
-        ("bgFeaturedSubtleInteractive", colors.bgFeaturedSubtleInteractive),
-        ("bgInfoInteractive", colors.bgInfoInteractive),
-        ("bgInfoSubtleInteractive", colors.bgInfoSubtleInteractive),
-        ("bgNeutralInteractive", colors.bgNeutralInteractive),
-        ("bgNeutralSubtleInteractive", colors.bgNeutralSubtleInteractive),
-        ("bgPositiveInteractive", colors.bgPositiveInteractive),
-        ("bgPositiveSubtleInteractive", colors.bgPositiveSubtleInteractive),
-        ("bgSubtleInteractive", colors.bgSubtleInteractive),
-        ("bgBrandElevatedPressed", colors.bgBrandElevatedPressed),
-        ("bgBrandHighPressed", colors.bgBrandHighPressed),
-        ("bgBrandPressed", colors.bgBrandPressed),
-        ("bgCautionPressed", colors.bgCautionPressed),
-        ("bgCautionSubtlePressed", colors.bgCautionSubtlePressed),
-        ("bgCriticalPressed", colors.bgCriticalPressed),
-        ("bgCriticalSubtlePressed", colors.bgCriticalSubtlePressed),
-        ("bgDefaultPressed", colors.bgDefaultPressed),
-        ("bgElevatedPressed", colors.bgElevatedPressed),
-        ("bgFeaturedPressed", colors.bgFeaturedPressed),
-        ("bgFeaturedSubtlePressed", colors.bgFeaturedSubtlePressed),
-        ("bgInfoPressed", colors.bgInfoPressed),
-        ("bgInfoSubtlePressed", colors.bgInfoSubtlePressed),
-        ("bgNeutralPressed", colors.bgNeutralPressed),
-        ("bgNeutralSubtlePressed", colors.bgNeutralSubtlePressed),
-        ("bgPositivePressed", colors.bgPositivePressed),
-        ("bgPositiveSubtlePressed", colors.bgPositiveSubtlePressed),
-        ("bgSubtlePressed", colors.bgSubtlePressed),
+        ("Interactive / Background", [
+            ("bgDefaultInteractive", colors.bgDefaultInteractive),
+            ("bgSubtleInteractive", colors.bgSubtleInteractive),
+            ("bgElevatedInteractive", colors.bgElevatedInteractive),
+            ("bgElevatedHighInteractive", colors.bgElevatedHighInteractive),
+            ("bgBrandInteractive", colors.bgBrandInteractive),
+            ("bgBrandElevatedInteractive", colors.bgBrandElevatedInteractive),
+            ("bgBrandHighInteractive", colors.bgBrandHighInteractive),
+            ("bgCriticalInteractive", colors.bgCriticalInteractive),
+            ("bgCautionInteractive", colors.bgCautionInteractive),
+            ("bgInfoInteractive", colors.bgInfoInteractive),
+            ("bgPositiveInteractive", colors.bgPositiveInteractive),
+            ("bgFeaturedInteractive", colors.bgFeaturedInteractive),
+            ("bgNeutralInteractive", colors.bgNeutralInteractive),
+            ("bgCriticalSubtleInteractive", colors.bgCriticalSubtleInteractive),
+            ("bgCautionSubtleInteractive", colors.bgCautionSubtleInteractive),
+            ("bgInfoSubtleInteractive", colors.bgInfoSubtleInteractive),
+            ("bgPositiveSubtleInteractive", colors.bgPositiveSubtleInteractive),
+            ("bgFeaturedSubtleInteractive", colors.bgFeaturedSubtleInteractive),
+            ("bgNeutralSubtleInteractive", colors.bgNeutralSubtleInteractive),
+            ("bgAlwaysDarkHighInteractive", colors.bgAlwaysDarkHighInteractive),
+            ("bgAlwaysDarkMediumInteractive", colors.bgAlwaysDarkMediumInteractive),
+            ("bgAlwaysDarkLowInteractive", colors.bgAlwaysDarkLowInteractive),
+            ("bgAlwaysLightHighInteractive", colors.bgAlwaysLightHighInteractive),
+            ("bgAlwaysLightMediumInteractive", colors.bgAlwaysLightMediumInteractive),
+            ("bgAlwaysLightLowInteractive", colors.bgAlwaysLightLowInteractive),
+        ]),
+        ("Pressed / Background", [
+            ("bgDefaultPressed", colors.bgDefaultPressed),
+            ("bgSubtlePressed", colors.bgSubtlePressed),
+            ("bgElevatedPressed", colors.bgElevatedPressed),
+            ("bgBrandPressed", colors.bgBrandPressed),
+            ("bgBrandElevatedPressed", colors.bgBrandElevatedPressed),
+            ("bgBrandHighPressed", colors.bgBrandHighPressed),
+            ("bgCriticalPressed", colors.bgCriticalPressed),
+            ("bgCautionPressed", colors.bgCautionPressed),
+            ("bgInfoPressed", colors.bgInfoPressed),
+            ("bgPositivePressed", colors.bgPositivePressed),
+            ("bgFeaturedPressed", colors.bgFeaturedPressed),
+            ("bgNeutralPressed", colors.bgNeutralPressed),
+            ("bgCriticalSubtlePressed", colors.bgCriticalSubtlePressed),
+            ("bgCautionSubtlePressed", colors.bgCautionSubtlePressed),
+            ("bgInfoSubtlePressed", colors.bgInfoSubtlePressed),
+            ("bgPositiveSubtlePressed", colors.bgPositiveSubtlePressed),
+            ("bgFeaturedSubtlePressed", colors.bgFeaturedSubtlePressed),
+            ("bgNeutralSubtlePressed", colors.bgNeutralSubtlePressed),
+        ]),
     ]
 }
 
-private func scopedTokens(_ colors: ScopedColors) -> [(String, Color)] {
+private func scopedTokens(_ colors: ScopedColors) -> [TokenSubgroup] {
     [
-        ("bgSettlementBusinessDays", colors.bgSettlementBusinessDays),
-        ("bgSettlementEveryday", colors.bgSettlementEveryday),
-        ("bgSettlementInstant", colors.bgSettlementInstant),
-        ("bgSettlementScheduled", colors.bgSettlementScheduled),
-        ("contentOnSettlementBusinessDays", colors.contentOnSettlementBusinessDays),
-        ("contentOnSettlementEveryday", colors.contentOnSettlementEveryday),
-        ("contentOnSettlementInstant", colors.contentOnSettlementInstant),
-        ("contentOnSettlementScheduled", colors.contentOnSettlementScheduled),
+        ("Settlements", [
+            ("bgSettlementInstant", colors.bgSettlementInstant),
+            ("bgSettlementBusinessDays", colors.bgSettlementBusinessDays),
+            ("bgSettlementEveryday", colors.bgSettlementEveryday),
+            ("bgSettlementScheduled", colors.bgSettlementScheduled),
+            ("contentOnSettlementInstant", colors.contentOnSettlementInstant),
+            ("contentOnSettlementBusinessDays", colors.contentOnSettlementBusinessDays),
+            ("contentOnSettlementEveryday", colors.contentOnSettlementEveryday),
+            ("contentOnSettlementScheduled", colors.contentOnSettlementScheduled),
+        ]),
     ]
 }
 
-private func shadowTokens(_ colors: ShadowColors) -> [(String, Color)] {
+private func shadowTokens(_ colors: ShadowColors) -> [TokenSubgroup] {
     [
-        ("shadowDefault", colors.shadowDefault),
+        (nil, [
+            ("shadowDefault", colors.shadowDefault),
+        ]),
     ]
 }
 

--- a/swiftui/SampleApp/ColorsDisplayView.swift
+++ b/swiftui/SampleApp/ColorsDisplayView.swift
@@ -9,7 +9,7 @@ struct ColorsDisplayView: View {
         ScrollView {
             LazyVStack(alignment: .leading, spacing: 0) {
                 ForEach(semanticGroups) { group in
-                    ColorSwatchSection(group: group)
+                    ColorSwatchSection(group: group, outlined: true)
                 }
             }
         }

--- a/swiftui/SampleApp/ColorsDisplayView.swift
+++ b/swiftui/SampleApp/ColorsDisplayView.swift
@@ -7,51 +7,53 @@ struct ColorsDisplayView: View {
 
     var body: some View {
         ScrollView {
-            LazyVStack(alignment: .leading, spacing: 24) {
-                ForEach(colorGroups, id: \.title) { group in
-                    VStack(alignment: .leading, spacing: 8) {
-                        Text(group.title)
-                            .font(.caption)
-                            .foregroundStyle(.content.contentSecondary)
-                            .textCase(.uppercase)
-
-                        VStack(spacing: 0) {
-                            ForEach(group.colors, id: \.name) { colorItem in
-                                HStack {
-                                    Text(colorItem.name)
-                                        .font(.caption2)
-                                        .fontWeight(.semibold)
-                                        .foregroundStyle(textColor(for: colorItem.color))
-                                    Spacer()
-                                }
-                                .padding(.horizontal, 12)
-                                .frame(height: 40)
-                                .background(colorItem.color)
-                            }
-                        }
-                        .clipShape(RoundedRectangle(cornerRadius: 8))
-                    }
+            LazyVStack(alignment: .leading, spacing: 0) {
+                ForEach(semanticGroups) { group in
+                    ColorSwatchSection(group: group)
                 }
             }
-            .padding()
         }
+        .background(.bg.bgDefault)
         .navigationTitle("Semantic Colors")
     }
 
-    /// Picks black or white for the swatch label, whichever has the higher WCAG contrast
-    /// against the swatch. `.primary` flips with the colour scheme rather than with the
-    /// swatch, so it disappears on any token whose lightness runs against the scheme.
-    private func textColor(for backgroundColor: Color) -> Color {
+    private var semanticGroups: [ColorSwatchGroup] {
+        let colors = LemonadeTheme.colors
+        return [
+            group(title: "Background", tokens: backgroundTokens(colors.background)),
+            group(title: "Border", tokens: borderTokens(colors.border)),
+            group(title: "Content", tokens: contentTokens(colors.content)),
+            group(title: "Interaction", tokens: interactionTokens(colors.interaction)),
+            group(title: "Scoped", tokens: scopedTokens(colors.scoped)),
+            group(title: "Shadow", tokens: shadowTokens(colors.shadow)),
+        ]
+    }
+
+    private func group(title: String, tokens: [(String, Color)]) -> ColorSwatchGroup {
+        ColorSwatchGroup(
+            title: title,
+            swatches: tokens.map { name, color in
+                ColorSwatch(path: title.lowercased(), name: name, fill: color, label: labelColor(for: color))
+            }
+        )
+    }
+
+    /// Picks whichever of the always-dark and always-light content tokens has the higher
+    /// WCAG contrast against the swatch. A scheme-relative token flips with the colour
+    /// scheme rather than with the swatch, so it disappears on any token whose lightness
+    /// runs against the scheme.
+    private func labelColor(for backgroundColor: Color) -> Color {
+        let content = LemonadeTheme.colors.content
         let traits = UITraitCollection(userInterfaceStyle: colorScheme == .dark ? .dark : .light)
         let swatch = UIColor(backgroundColor).resolvedColor(with: traits)
         let page = UIColor(LemonadeTheme.colors.background.bgDefault).resolvedColor(with: traits)
 
         var red: CGFloat = 0, green: CGFloat = 0, blue: CGFloat = 0, alpha: CGFloat = 0
-        guard swatch.getRed(&red, green: &green, blue: &blue, alpha: &alpha) else { return .primary }
+        guard swatch.getRed(&red, green: &green, blue: &blue, alpha: &alpha) else { return content.contentPrimary }
 
         var pageRed: CGFloat = 0, pageGreen: CGFloat = 0, pageBlue: CGFloat = 0, pageAlpha: CGFloat = 0
         guard page.getRed(&pageRed, green: &pageGreen, blue: &pageBlue, alpha: &pageAlpha) else {
-            return .primary
+            return content.contentPrimary
         }
 
         // Translucent tokens are drawn over the page background, so the luminance that
@@ -67,7 +69,7 @@ struct ColorsDisplayView: View {
             + 0.0722 * linearised(composited.blue)
 
         // 0.179 is where contrast against black overtakes contrast against white.
-        return luminance > 0.179 ? .black : .white
+        return luminance > 0.179 ? content.contentAlwaysDark : content.contentAlwaysLight
     }
 
     private func linearised(_ channel: CGFloat) -> Double {
@@ -76,64 +78,184 @@ struct ColorsDisplayView: View {
     }
 }
 
-// MARK: - Color Data
+// MARK: - Semantic Color Data
 
-struct ColorItem: Identifiable {
-    let id = UUID()
-    let name: String
-    let color: Color
+private func backgroundTokens(_ colors: BackgroundColors) -> [(String, Color)] {
+    [
+        ("bgBrand", colors.bgBrand),
+        ("bgBrandElevated", colors.bgBrandElevated),
+        ("bgBrandHigh", colors.bgBrandHigh),
+        ("bgBrandSubtle", colors.bgBrandSubtle),
+        ("bgAlwaysDark", colors.bgAlwaysDark),
+        ("bgAlwaysDarkHigh", colors.bgAlwaysDarkHigh),
+        ("bgAlwaysDarkLow", colors.bgAlwaysDarkLow),
+        ("bgAlwaysDarkMedium", colors.bgAlwaysDarkMedium),
+        ("bgAlwaysLight", colors.bgAlwaysLight),
+        ("bgAlwaysLightHigh", colors.bgAlwaysLightHigh),
+        ("bgAlwaysLightLow", colors.bgAlwaysLightLow),
+        ("bgAlwaysLightMedium", colors.bgAlwaysLightMedium),
+        ("bgTransparent", colors.bgTransparent),
+        ("bgTransparentDark", colors.bgTransparentDark),
+        ("bgTransparentLight", colors.bgTransparentLight),
+        ("bgDefaultInverse", colors.bgDefaultInverse),
+        ("bgElevatedInverse", colors.bgElevatedInverse),
+        ("bgSubtleInverse", colors.bgSubtleInverse),
+        ("bgCaution", colors.bgCaution),
+        ("bgCautionSubtle", colors.bgCautionSubtle),
+        ("bgCritical", colors.bgCritical),
+        ("bgCriticalSubtle", colors.bgCriticalSubtle),
+        ("bgFeatured", colors.bgFeatured),
+        ("bgFeaturedSubtle", colors.bgFeaturedSubtle),
+        ("bgInfo", colors.bgInfo),
+        ("bgInfoSubtle", colors.bgInfoSubtle),
+        ("bgNeutral", colors.bgNeutral),
+        ("bgNeutralSubtle", colors.bgNeutralSubtle),
+        ("bgPositive", colors.bgPositive),
+        ("bgPositiveSubtle", colors.bgPositiveSubtle),
+        ("bgDefault", colors.bgDefault),
+        ("bgElevated", colors.bgElevated),
+        ("bgElevatedHigh", colors.bgElevatedHigh),
+        ("bgSubtle", colors.bgSubtle),
+    ]
 }
 
-struct ColorGroup: Identifiable {
-    let id = UUID()
-    let title: String
-    let colors: [ColorItem]
+private func borderTokens(_ colors: BorderColors) -> [(String, Color)] {
+    [
+        ("borderBrand", colors.borderBrand),
+        ("borderOnBrandHigh", colors.borderOnBrandHigh),
+        ("borderOnBrandLow", colors.borderOnBrandLow),
+        ("borderOnBrandMedium", colors.borderOnBrandMedium),
+        ("borderAlwaysDark", colors.borderAlwaysDark),
+        ("borderAlwaysDarkHigh", colors.borderAlwaysDarkHigh),
+        ("borderAlwaysDarkLow", colors.borderAlwaysDarkLow),
+        ("borderAlwaysDarkMedium", colors.borderAlwaysDarkMedium),
+        ("borderAlwaysLight", colors.borderAlwaysLight),
+        ("borderAlwaysLightHigh", colors.borderAlwaysLightHigh),
+        ("borderAlwaysLightLow", colors.borderAlwaysLightLow),
+        ("borderAlwaysLightMedium", colors.borderAlwaysLightMedium),
+        ("borderBrandInverse", colors.borderBrandInverse),
+        ("borderNeutralHighInverse", colors.borderNeutralHighInverse),
+        ("borderNeutralLowInverse", colors.borderNeutralLowInverse),
+        ("borderNeutralMediumInverse", colors.borderNeutralMediumInverse),
+        ("borderSelectedInverse", colors.borderSelectedInverse),
+        ("borderCaution", colors.borderCaution),
+        ("borderCautionSubtle", colors.borderCautionSubtle),
+        ("borderCritical", colors.borderCritical),
+        ("borderCriticalSubtle", colors.borderCriticalSubtle),
+        ("borderFeatured", colors.borderFeatured),
+        ("borderFeaturedSubtle", colors.borderFeaturedSubtle),
+        ("borderInfo", colors.borderInfo),
+        ("borderInfoSubtle", colors.borderInfoSubtle),
+        ("borderPositive", colors.borderPositive),
+        ("borderPositiveSubtle", colors.borderPositiveSubtle),
+        ("borderNeutralHigh", colors.borderNeutralHigh),
+        ("borderNeutralLow", colors.borderNeutralLow),
+        ("borderNeutralMedium", colors.borderNeutralMedium),
+        ("borderSelected", colors.borderSelected),
+    ]
 }
 
-private let colorGroups: [ColorGroup] = [
-    ColorGroup(title: "Background", colors: [
-        ColorItem(name: "bgDefault", color: .bg.bgDefault),
-        ColorItem(name: "bgSubtle", color: .bg.bgSubtle),
-        ColorItem(name: "bgElevated", color: .bg.bgElevated),
-        ColorItem(name: "bgElevatedHigh", color: .bg.bgElevatedHigh),
-        ColorItem(name: "bgBrand", color: .bg.bgBrand),
-        ColorItem(name: "bgBrandHigh", color: .bg.bgBrandHigh),
-        ColorItem(name: "bgBrandSubtle", color: .bg.bgBrandSubtle),
-        ColorItem(name: "bgPositive", color: .bg.bgPositive),
-        ColorItem(name: "bgPositiveSubtle", color: .bg.bgPositiveSubtle),
-        ColorItem(name: "bgCritical", color: .bg.bgCritical),
-        ColorItem(name: "bgCriticalSubtle", color: .bg.bgCriticalSubtle),
-        ColorItem(name: "bgCaution", color: .bg.bgCaution),
-        ColorItem(name: "bgCautionSubtle", color: .bg.bgCautionSubtle),
-        ColorItem(name: "bgInfo", color: .bg.bgInfo),
-        ColorItem(name: "bgInfoSubtle", color: .bg.bgInfoSubtle),
-        ColorItem(name: "bgNeutral", color: .bg.bgNeutral),
-        ColorItem(name: "bgNeutralSubtle", color: .bg.bgNeutralSubtle),
-    ]),
-    ColorGroup(title: "Content", colors: [
-        ColorItem(name: "contentPrimary", color: .content.contentPrimary),
-        ColorItem(name: "contentSecondary", color: .content.contentSecondary),
-        ColorItem(name: "contentTertiary", color: .content.contentTertiary),
-        ColorItem(name: "contentBrand", color: .content.contentBrand),
-        ColorItem(name: "contentBrandHigh", color: .content.contentBrandHigh),
-        ColorItem(name: "contentPositive", color: .content.contentPositive),
-        ColorItem(name: "contentCritical", color: .content.contentCritical),
-        ColorItem(name: "contentCaution", color: .content.contentCaution),
-        ColorItem(name: "contentInfo", color: .content.contentInfo),
-        ColorItem(name: "contentNeutral", color: .content.contentNeutral),
-    ]),
-    ColorGroup(title: "Border", colors: [
-        ColorItem(name: "borderNeutralLow", color: .border.borderNeutralLow),
-        ColorItem(name: "borderNeutralMedium", color: .border.borderNeutralMedium),
-        ColorItem(name: "borderNeutralHigh", color: .border.borderNeutralHigh),
-        ColorItem(name: "borderBrand", color: .border.borderBrand),
-        ColorItem(name: "borderSelected", color: .border.borderSelected),
-        ColorItem(name: "borderPositive", color: .border.borderPositive),
-        ColorItem(name: "borderCritical", color: .border.borderCritical),
-        ColorItem(name: "borderCaution", color: .border.borderCaution),
-        ColorItem(name: "borderInfo", color: .border.borderInfo),
-    ]),
-]
+private func contentTokens(_ colors: ContentColors) -> [(String, Color)] {
+    [
+        ("contentBrand", colors.contentBrand),
+        ("contentBrandHigh", colors.contentBrandHigh),
+        ("contentOnBrandHigh", colors.contentOnBrandHigh),
+        ("contentOnBrandLow", colors.contentOnBrandLow),
+        ("contentAlwaysDark", colors.contentAlwaysDark),
+        ("contentAlwaysLight", colors.contentAlwaysLight),
+        ("contentCautionAlwaysOnColor", colors.contentCautionAlwaysOnColor),
+        ("contentCriticalAlwaysOnColor", colors.contentCriticalAlwaysOnColor),
+        ("contentInfoAlwaysOnColor", colors.contentInfoAlwaysOnColor),
+        ("contentNeutralAlwaysOnColor", colors.contentNeutralAlwaysOnColor),
+        ("contentPositiveAlwaysOnColor", colors.contentPositiveAlwaysOnColor),
+        ("contentBrandInverse", colors.contentBrandInverse),
+        ("contentPrimaryInverse", colors.contentPrimaryInverse),
+        ("contentSecondaryInverse", colors.contentSecondaryInverse),
+        ("contentTertiaryInverse", colors.contentTertiaryInverse),
+        ("contentCautionOnColor", colors.contentCautionOnColor),
+        ("contentCriticalOnColor", colors.contentCriticalOnColor),
+        ("contentFeaturedOnColor", colors.contentFeaturedOnColor),
+        ("contentInfoOnColor", colors.contentInfoOnColor),
+        ("contentNeutralOnColor", colors.contentNeutralOnColor),
+        ("contentPositiveOnColor", colors.contentPositiveOnColor),
+        ("contentCaution", colors.contentCaution),
+        ("contentCritical", colors.contentCritical),
+        ("contentFeatured", colors.contentFeatured),
+        ("contentInfo", colors.contentInfo),
+        ("contentNeutral", colors.contentNeutral),
+        ("contentPositive", colors.contentPositive),
+        ("contentPrimary", colors.contentPrimary),
+        ("contentSecondary", colors.contentSecondary),
+        ("contentTertiary", colors.contentTertiary),
+    ]
+}
+
+private func interactionTokens(_ colors: InteractionColors) -> [(String, Color)] {
+    [
+        ("bgAlwaysDarkHighInteractive", colors.bgAlwaysDarkHighInteractive),
+        ("bgAlwaysDarkLowInteractive", colors.bgAlwaysDarkLowInteractive),
+        ("bgAlwaysDarkMediumInteractive", colors.bgAlwaysDarkMediumInteractive),
+        ("bgAlwaysLightHighInteractive", colors.bgAlwaysLightHighInteractive),
+        ("bgAlwaysLightLowInteractive", colors.bgAlwaysLightLowInteractive),
+        ("bgAlwaysLightMediumInteractive", colors.bgAlwaysLightMediumInteractive),
+        ("bgBrandElevatedInteractive", colors.bgBrandElevatedInteractive),
+        ("bgBrandHighInteractive", colors.bgBrandHighInteractive),
+        ("bgBrandInteractive", colors.bgBrandInteractive),
+        ("bgCautionInteractive", colors.bgCautionInteractive),
+        ("bgCautionSubtleInteractive", colors.bgCautionSubtleInteractive),
+        ("bgCriticalInteractive", colors.bgCriticalInteractive),
+        ("bgCriticalSubtleInteractive", colors.bgCriticalSubtleInteractive),
+        ("bgDefaultInteractive", colors.bgDefaultInteractive),
+        ("bgElevatedHighInteractive", colors.bgElevatedHighInteractive),
+        ("bgElevatedInteractive", colors.bgElevatedInteractive),
+        ("bgFeaturedInteractive", colors.bgFeaturedInteractive),
+        ("bgFeaturedSubtleInteractive", colors.bgFeaturedSubtleInteractive),
+        ("bgInfoInteractive", colors.bgInfoInteractive),
+        ("bgInfoSubtleInteractive", colors.bgInfoSubtleInteractive),
+        ("bgNeutralInteractive", colors.bgNeutralInteractive),
+        ("bgNeutralSubtleInteractive", colors.bgNeutralSubtleInteractive),
+        ("bgPositiveInteractive", colors.bgPositiveInteractive),
+        ("bgPositiveSubtleInteractive", colors.bgPositiveSubtleInteractive),
+        ("bgSubtleInteractive", colors.bgSubtleInteractive),
+        ("bgBrandElevatedPressed", colors.bgBrandElevatedPressed),
+        ("bgBrandHighPressed", colors.bgBrandHighPressed),
+        ("bgBrandPressed", colors.bgBrandPressed),
+        ("bgCautionPressed", colors.bgCautionPressed),
+        ("bgCautionSubtlePressed", colors.bgCautionSubtlePressed),
+        ("bgCriticalPressed", colors.bgCriticalPressed),
+        ("bgCriticalSubtlePressed", colors.bgCriticalSubtlePressed),
+        ("bgDefaultPressed", colors.bgDefaultPressed),
+        ("bgElevatedPressed", colors.bgElevatedPressed),
+        ("bgFeaturedPressed", colors.bgFeaturedPressed),
+        ("bgFeaturedSubtlePressed", colors.bgFeaturedSubtlePressed),
+        ("bgInfoPressed", colors.bgInfoPressed),
+        ("bgInfoSubtlePressed", colors.bgInfoSubtlePressed),
+        ("bgNeutralPressed", colors.bgNeutralPressed),
+        ("bgNeutralSubtlePressed", colors.bgNeutralSubtlePressed),
+        ("bgPositivePressed", colors.bgPositivePressed),
+        ("bgPositiveSubtlePressed", colors.bgPositiveSubtlePressed),
+        ("bgSubtlePressed", colors.bgSubtlePressed),
+    ]
+}
+
+private func scopedTokens(_ colors: ScopedColors) -> [(String, Color)] {
+    [
+        ("bgSettlementBusinessDays", colors.bgSettlementBusinessDays),
+        ("bgSettlementEveryday", colors.bgSettlementEveryday),
+        ("bgSettlementInstant", colors.bgSettlementInstant),
+        ("bgSettlementScheduled", colors.bgSettlementScheduled),
+        ("contentOnSettlementBusinessDays", colors.contentOnSettlementBusinessDays),
+        ("contentOnSettlementEveryday", colors.contentOnSettlementEveryday),
+        ("contentOnSettlementInstant", colors.contentOnSettlementInstant),
+        ("contentOnSettlementScheduled", colors.contentOnSettlementScheduled),
+    ]
+}
+
+private func shadowTokens(_ colors: ShadowColors) -> [(String, Color)] {
+    [
+        ("shadowDefault", colors.shadowDefault),
+    ]
+}
 
 #Preview {
     NavigationStack {

--- a/swiftui/SampleApp/HomeView.swift
+++ b/swiftui/SampleApp/HomeView.swift
@@ -79,7 +79,7 @@ private struct DemoSection: Identifiable {
 private let demoSections: [DemoSection] = [
     DemoSection(
         title: "Foundations",
-        items: [.colors, .themedColors, .spacing, .radius, .shadows, .sizes, .opacity, .borderWidth]
+        items: [.themedColors, .colors, .spacing, .radius, .shadows, .sizes, .opacity, .borderWidth]
     ),
     DemoSection(
         title: "Assets",

--- a/swiftui/SampleApp/HomeView.swift
+++ b/swiftui/SampleApp/HomeView.swift
@@ -9,8 +9,8 @@ import Lemonade
 /// building an `AnyView` per entry) means a destination view is only constructed
 /// when the user actually pushes it. The raw value doubles as the display title.
 private enum Demo: String, CaseIterable, Identifiable, Hashable {
-    case colors = "Semantic Colors"
     case themedColors = "Themed Colors"
+    case semanticColors = "Semantic Colors"
     case spacing = "Spacing"
     case radius = "Radius"
     case shadows = "Shadows"
@@ -79,7 +79,7 @@ private struct DemoSection: Identifiable {
 private let demoSections: [DemoSection] = [
     DemoSection(
         title: "Foundations",
-        items: [.themedColors, .colors, .spacing, .radius, .shadows, .sizes, .opacity, .borderWidth]
+        items: [.themedColors, .semanticColors, .spacing, .radius, .shadows, .sizes, .opacity, .borderWidth]
     ),
     DemoSection(
         title: "Assets",
@@ -178,8 +178,8 @@ struct HomeView: View {
     @ViewBuilder
     private func destination(for demo: Demo) -> some View {
         switch demo {
-        case .colors: ColorsDisplayView()
         case .themedColors: ThemedColorsDisplayView()
+        case .semanticColors: SemanticColorsDisplayView()
         case .spacing: SpacingDisplayView()
         case .radius: RadiusDisplayView()
         case .shadows: ShadowsDisplayView()

--- a/swiftui/SampleApp/HomeView.swift
+++ b/swiftui/SampleApp/HomeView.swift
@@ -9,7 +9,7 @@ import Lemonade
 /// building an `AnyView` per entry) means a destination view is only constructed
 /// when the user actually pushes it. The raw value doubles as the display title.
 private enum Demo: String, CaseIterable, Identifiable, Hashable {
-    case colors = "Colors"
+    case colors = "Semantic Colors"
     case themedColors = "Themed Colors"
     case spacing = "Spacing"
     case radius = "Radius"

--- a/swiftui/SampleApp/SemanticColorsDisplayView.swift
+++ b/swiftui/SampleApp/SemanticColorsDisplayView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import UIKit
 import Lemonade
 
-struct ColorsDisplayView: View {
+struct SemanticColorsDisplayView: View {
     @Environment(\.colorScheme) private var colorScheme
 
     var body: some View {
@@ -17,7 +17,7 @@ struct ColorsDisplayView: View {
                     .padding(.top, LemonadeTheme.spaces.spacing600)
 
                     ForEach(group.subgroups) { subgroup in
-                        ColorSwatchSection(title: subgroup.title, swatches: subgroup.swatches, outlined: true)
+                        ColorSwatchSection(group: subgroup, outlined: true)
                     }
                 }
             }
@@ -43,7 +43,7 @@ struct ColorsDisplayView: View {
             title: title,
             subgroups: subgroups.map { subgroup in
                 let path = (subgroup.title ?? title).lowercased()
-                return SemanticSubgroup(
+                return ColorSwatchGroup(
                     id: "\(title)/\(subgroup.title ?? "")",
                     title: subgroup.title,
                     swatches: subgroup.tokens.map { name, color in
@@ -99,19 +99,10 @@ struct ColorsDisplayView: View {
 private struct SemanticGroup: Identifiable {
     var id: String { title }
     let title: String
-    let subgroups: [SemanticSubgroup]
-}
-
-/// Sub-group titles repeat across groups, and the lazy stack flattens every group's
-/// sub-groups into one list, so the id has to carry the group too.
-private struct SemanticSubgroup: Identifiable {
-    let id: String
-    let title: String?
-    let swatches: [ColorSwatch]
+    let subgroups: [ColorSwatchGroup]
 }
 
 private typealias TokenSubgroup = (title: String?, tokens: [(String, Color)])
-
 
 private func backgroundTokens(_ colors: BackgroundColors) -> [TokenSubgroup] {
     [
@@ -332,6 +323,6 @@ private func shadowTokens(_ colors: ShadowColors) -> [TokenSubgroup] {
 
 #Preview {
     NavigationStack {
-        ColorsDisplayView()
+        SemanticColorsDisplayView()
     }
 }

--- a/swiftui/SampleApp/ThemedColorsDisplayView.swift
+++ b/swiftui/SampleApp/ThemedColorsDisplayView.swift
@@ -6,7 +6,7 @@ struct ThemedColorsDisplayView: View {
         ScrollView {
             LazyVStack(alignment: .leading, spacing: 0) {
                 ForEach(themedHues) { hue in
-                    ThemedHueSection(hue: hue)
+                    ColorSwatchSection(group: hue)
                 }
             }
         }
@@ -15,108 +15,45 @@ struct ThemedColorsDisplayView: View {
     }
 }
 
-private struct ThemedHueSection: View {
-    let hue: ThemedHue
+// MARK: - Themed Color Data
 
-    private let columns = Array(
-        repeating: GridItem(.flexible(), spacing: LemonadeTheme.spaces.spacing200),
-        count: 2
-    )
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: LemonadeTheme.spaces.spacing200) {
-            LemonadeUi.Text(
-                hue.title,
-                textStyle: LemonadeTypography.shared.headingXXSmall
-            )
-            .padding(.horizontal, LemonadeTheme.spaces.spacing100)
-
-            LazyVGrid(columns: columns, spacing: LemonadeTheme.spaces.spacing200) {
-                ForEach(hue.swatches) { swatch in
-                    ThemedSwatchView(swatch: swatch)
-                }
-            }
-        }
-        .padding(LemonadeTheme.spaces.spacing400)
-    }
-}
-
-private struct ThemedSwatchView: View {
-    let swatch: ThemedSwatch
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            LemonadeUi.Text(
-                swatch.path,
-                textStyle: LemonadeTypography.shared.bodyXSmallRegular,
-                color: swatch.label.opacity(LemonadeTheme.opacity.base.opacity70)
-            )
-
-            Spacer(minLength: 0)
-
-            LemonadeUi.Text(
-                swatch.slot,
-                textStyle: LemonadeTypography.shared.bodyXSmallMedium,
-                color: swatch.label
-            )
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
-        .padding(.horizontal, LemonadeTheme.spaces.spacing400)
-        .padding(.vertical, LemonadeTheme.spaces.spacing500)
-        .frame(height: 162)
-        .background(swatch.fill, in: LemonadeTheme.shapes.radius600)
-    }
-}
-
-private struct ThemedSwatch: Identifiable {
-    var id: String { "\(path).\(slot)" }
-    let path: String
-    let slot: String
-    let fill: Color
-    let label: Color
-}
-
-private struct ThemedHue: Identifiable {
-    var id: String { title }
-    let title: String
-    let swatches: [ThemedSwatch]
-
-    init(title: String, name: String, color: ThemedPrimaryColor) {
-        let subtle = "\(name).subtle"
-        self.title = title
-        self.swatches = [
-            ThemedSwatch(path: name, slot: "background", fill: color.background, label: color.onBackground),
-            ThemedSwatch(path: name, slot: "border", fill: color.border, label: color.onBackground),
-            ThemedSwatch(path: name, slot: "content", fill: color.content, label: color.contentInverse),
-            ThemedSwatch(path: name, slot: "contentInverse", fill: color.contentInverse, label: color.onBackground),
-            ThemedSwatch(path: name, slot: "onBackground", fill: color.onBackground, label: color.content),
-            ThemedSwatch(path: name, slot: "backgroundHigh", fill: color.backgroundHigh, label: color.contentInverse),
-            ThemedSwatch(path: name, slot: "onBackgroundHigh", fill: color.onBackgroundHigh, label: color.content),
-            ThemedSwatch(path: subtle, slot: "background", fill: color.subtle.background, label: color.subtle.onBackground),
-            ThemedSwatch(path: subtle, slot: "border", fill: color.subtle.border, label: color.subtle.onBackground),
-            ThemedSwatch(path: subtle, slot: "onBackground", fill: color.subtle.onBackground, label: color.contentInverse),
+private func themedHue(title: String, name: String, color: ThemedPrimaryColor) -> ColorSwatchGroup {
+    let subtle = "\(name).subtle"
+    return ColorSwatchGroup(
+        title: title,
+        swatches: [
+            ColorSwatch(path: name, name: "background", fill: color.background, label: color.onBackground),
+            ColorSwatch(path: name, name: "border", fill: color.border, label: color.onBackground),
+            ColorSwatch(path: name, name: "content", fill: color.content, label: color.contentInverse),
+            ColorSwatch(path: name, name: "contentInverse", fill: color.contentInverse, label: color.onBackground),
+            ColorSwatch(path: name, name: "onBackground", fill: color.onBackground, label: color.content),
+            ColorSwatch(path: name, name: "backgroundHigh", fill: color.backgroundHigh, label: color.contentInverse),
+            ColorSwatch(path: name, name: "onBackgroundHigh", fill: color.onBackgroundHigh, label: color.content),
+            ColorSwatch(path: subtle, name: "background", fill: color.subtle.background, label: color.subtle.onBackground),
+            ColorSwatch(path: subtle, name: "border", fill: color.subtle.border, label: color.subtle.onBackground),
+            ColorSwatch(path: subtle, name: "onBackground", fill: color.subtle.onBackground, label: color.contentInverse),
         ]
-    }
+    )
 }
 
-private let themedHues: [ThemedHue] = [
-    ThemedHue(title: "Amber", name: "amber", color: LemonadeTheme.themed.amber),
-    ThemedHue(title: "Blue", name: "blue", color: LemonadeTheme.themed.blue),
-    ThemedHue(title: "Cyan", name: "cyan", color: LemonadeTheme.themed.cyan),
-    ThemedHue(title: "Fuchsia", name: "fuchsia", color: LemonadeTheme.themed.fuchsia),
-    ThemedHue(title: "Green", name: "green", color: LemonadeTheme.themed.green),
-    ThemedHue(title: "Green Lime", name: "greenLime", color: LemonadeTheme.themed.greenLime),
-    ThemedHue(title: "Indigo", name: "indigo", color: LemonadeTheme.themed.indigo),
-    ThemedHue(title: "Neutral", name: "neutral", color: LemonadeTheme.themed.neutral),
-    ThemedHue(title: "Orange", name: "orange", color: LemonadeTheme.themed.orange),
-    ThemedHue(title: "Pink", name: "pink", color: LemonadeTheme.themed.pink),
-    ThemedHue(title: "Purple", name: "purple", color: LemonadeTheme.themed.purple),
-    ThemedHue(title: "Red", name: "red", color: LemonadeTheme.themed.red),
-    ThemedHue(title: "Rose", name: "rose", color: LemonadeTheme.themed.rose),
-    ThemedHue(title: "Teal", name: "teal", color: LemonadeTheme.themed.teal),
-    ThemedHue(title: "Violet", name: "violet", color: LemonadeTheme.themed.violet),
-    ThemedHue(title: "Yellow", name: "yellow", color: LemonadeTheme.themed.yellow),
-    ThemedHue(title: "Yellow Lime", name: "yellowLime", color: LemonadeTheme.themed.yellowLime),
+private let themedHues: [ColorSwatchGroup] = [
+    themedHue(title: "Amber", name: "amber", color: LemonadeTheme.themed.amber),
+    themedHue(title: "Blue", name: "blue", color: LemonadeTheme.themed.blue),
+    themedHue(title: "Cyan", name: "cyan", color: LemonadeTheme.themed.cyan),
+    themedHue(title: "Fuchsia", name: "fuchsia", color: LemonadeTheme.themed.fuchsia),
+    themedHue(title: "Green", name: "green", color: LemonadeTheme.themed.green),
+    themedHue(title: "Green Lime", name: "greenLime", color: LemonadeTheme.themed.greenLime),
+    themedHue(title: "Indigo", name: "indigo", color: LemonadeTheme.themed.indigo),
+    themedHue(title: "Neutral", name: "neutral", color: LemonadeTheme.themed.neutral),
+    themedHue(title: "Orange", name: "orange", color: LemonadeTheme.themed.orange),
+    themedHue(title: "Pink", name: "pink", color: LemonadeTheme.themed.pink),
+    themedHue(title: "Purple", name: "purple", color: LemonadeTheme.themed.purple),
+    themedHue(title: "Red", name: "red", color: LemonadeTheme.themed.red),
+    themedHue(title: "Rose", name: "rose", color: LemonadeTheme.themed.rose),
+    themedHue(title: "Teal", name: "teal", color: LemonadeTheme.themed.teal),
+    themedHue(title: "Violet", name: "violet", color: LemonadeTheme.themed.violet),
+    themedHue(title: "Yellow", name: "yellow", color: LemonadeTheme.themed.yellow),
+    themedHue(title: "Yellow Lime", name: "yellowLime", color: LemonadeTheme.themed.yellowLime),
 ]
 
 #Preview {

--- a/swiftui/SampleApp/ThemedColorsDisplayView.swift
+++ b/swiftui/SampleApp/ThemedColorsDisplayView.swift
@@ -6,7 +6,7 @@ struct ThemedColorsDisplayView: View {
         ScrollView {
             LazyVStack(alignment: .leading, spacing: 0) {
                 ForEach(themedHues) { hue in
-                    ColorSwatchSection(title: hue.title, swatches: hue.swatches)
+                    ColorSwatchSection(group: hue)
                 }
             }
         }
@@ -20,6 +20,7 @@ struct ThemedColorsDisplayView: View {
 private func themedHue(title: String, name: String, color: ThemedPrimaryColor) -> ColorSwatchGroup {
     let subtle = "\(name).subtle"
     return ColorSwatchGroup(
+        id: name,
         title: title,
         swatches: [
             ColorSwatch(path: name, name: "background", fill: color.background, label: color.onBackground),

--- a/swiftui/SampleApp/ThemedColorsDisplayView.swift
+++ b/swiftui/SampleApp/ThemedColorsDisplayView.swift
@@ -6,7 +6,7 @@ struct ThemedColorsDisplayView: View {
         ScrollView {
             LazyVStack(alignment: .leading, spacing: 0) {
                 ForEach(themedHues) { hue in
-                    ColorSwatchSection(group: hue)
+                    ColorSwatchSection(title: hue.title, swatches: hue.swatches)
                 }
             }
         }


### PR DESCRIPTION
# Summary

Gives the semantic colours the same swatch-grid page as Themed Colors, on both sample apps. Stacked on #397.

Why: the SwiftUI page showed a hand-picked 36 of ~145 semantic tokens as thin bands, and KMP had no semantic page at all (its "Colors" page is the primitive ramps).

- **SwiftUI:** the semantic page is rebuilt as the swatch grid and renamed `SemanticColorsDisplayView` (home entry **Semantic Colors**), since KMP's `ColorsDisplay` is the primitives page.
- **KMP:** new `SemanticColorsDisplay` page.
- **All tokens, sub-grouped:** every published token, under Background / Border / Content / Interaction / Scoped / Shadow and then the Figma sub-groups (Brand, Voice, Inverse, Fixed, …). Tokens outside a sub-group come first under the group heading. Sub-groups and tokens follow the Figma file's order, since the API has no grouping; the lists were generated from the token JSON and every name is compiler-checked.
- **Order:** Foundations lists Themed Colors before Semantic Colors on both apps, following the token layering.
- **Shared swatch:** the grid moves into `ColorSwatchSection` (one per platform), now used by both colour pages.
- **Outline:** semantic swatches get a `borderNeutralLow` outline so tokens matching the page (`bgDefault`, `bgBrandElevated`) stay visible. Themed Colors keeps the unoutlined Figma design.
- **Labels:** `contentAlwaysDark` or `contentAlwaysLight`, whichever contrasts more with the swatch composited over the page.

### How to test

1. SwiftUI: `cd swiftui && ./scripts/generate-ios-project.sh`, run `LemonadeSampleApp`, open **Foundations → Semantic Colors**. Toggle light and dark.
2. KMP: `cd kmp && ./gradlew :composeApp:run`, open **Semantic Colors**.
3. **Themed Colors** looks the same as in #397.

## Evidences
https://github.com/user-attachments/assets/b1b2073a-82c5-43cc-96e7-a14359790fe9

## API Dump

No public API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)