### PR TITLE
feat(swiftui): let the Spinner take a size

### DIFF
--- a/swiftui/SampleApp/SpinnerDisplayView.swift
+++ b/swiftui/SampleApp/SpinnerDisplayView.swift
@@ -6,6 +6,7 @@ struct SpinnerDisplayView: View {
         ScrollView {
             LazyVStack(alignment: .leading, spacing: 32) {
                 defaultSection
+                sizesSection
                 customTintSection
                 loadingButtonsSection
             }
@@ -19,6 +20,31 @@ struct SpinnerDisplayView: View {
             LemonadeUi.Spinner()
         }
     }
+
+    private var sizesSection: some View {
+        sectionView(title: "Sizes") {
+            HStack(alignment: .bottom, spacing: 12) {
+                ForEach(sizes, id: \.label) { size in
+                    VStack(spacing: 8) {
+                        LemonadeUi.Spinner(size: size.value)
+                        Text(size.label)
+                            .font(.caption)
+                    }
+                }
+            }
+        }
+    }
+
+    private let sizes: [(label: String, value: LemonadeSpinnerSize)] = [
+        ("XS", .xSmall),
+        ("S", .small),
+        ("M", .medium),
+        ("L", .large),
+        ("XL", .xLarge),
+        ("2XL", .xxLarge),
+        ("3XL", .xxxLarge),
+        ("4XL", .xxxxLarge),
+    ]
 
     private var customTintSection: some View {
         sectionView(title: "Custom Tint") {

--- a/swiftui/Sources/Lemonade/Components/LemonadeSpinner.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeSpinner.swift
@@ -1,25 +1,81 @@
 import SwiftUI
 
+// MARK: - Spinner Size
+
+/// Sizes a ``LemonadeUi/Spinner(size:tint:)`` can take, matching the Compose component.
+public enum LemonadeSpinnerSize {
+    case xSmall
+    case small
+    case medium
+    case large
+    case xLarge
+    case xxLarge
+    case xxxLarge
+    case xxxxLarge
+
+    /// Returns the CGFloat value for this size
+    public var value: CGFloat {
+        switch self {
+        case .xSmall: return LemonadeTheme.sizes.size300
+        case .small: return LemonadeTheme.sizes.size400
+        case .medium: return LemonadeTheme.sizes.size500
+        case .large: return LemonadeTheme.sizes.size600
+        case .xLarge: return LemonadeTheme.sizes.size800
+        case .xxLarge: return LemonadeTheme.sizes.size1000
+        case .xxxLarge: return LemonadeTheme.sizes.size1200
+        case .xxxxLarge: return LemonadeTheme.sizes.size1400
+        }
+    }
+}
+
 // MARK: - Spinner Component
 
 public extension LemonadeUi {
     /// Spinner component for indicating loading state.
-    /// Wraps the native iOS ProgressView with a customizable tint color.
+    /// Wraps the native iOS ProgressView with a customizable size and tint color.
     ///
     /// ## Usage
     /// ```swift
     /// LemonadeUi.Spinner()
+    /// LemonadeUi.Spinner(size: .large)
     /// LemonadeUi.Spinner(tint: LemonadeTheme.colors.content.contentBrand)
     /// ```
     ///
-    /// - Parameter tint: The spinner color. Defaults to `contentSecondary`
+    /// - Parameters:
+    ///   - size: The spinner size. Defaults to `.medium`
+    ///   - tint: The spinner color. Defaults to `contentSecondary`
     /// - Returns: A styled spinner view
     @ViewBuilder
     static func Spinner(
+        size: LemonadeSpinnerSize = .medium,
         tint: Color = LemonadeTheme.colors.content.contentSecondary
     ) -> some View {
         ProgressView()
+            .controlSize(size.controlSize)
             .tint(tint)
+            .scaleEffect(size.value / size.controlSize.spinnerDimension)
+            .frame(width: size.value, height: size.value)
+    }
+}
+
+// ProgressView only draws at a fixed size per control size and scaleEffect
+// stretches its bitmap, so each size scales from the closest native one to keep
+// upscaling, and the blur it causes, to a minimum.
+private extension LemonadeSpinnerSize {
+    var controlSize: ControlSize {
+        value > ControlSize.regular.spinnerDimension ? .large : .regular
+    }
+}
+
+// ProgressView's measured native sizes. iOS's large spinner is 37pt, which no
+// size token matches.
+private extension ControlSize {
+    var spinnerDimension: CGFloat {
+        #if os(macOS)
+        return LemonadeTheme.sizes.size800
+        #else
+        return self == .large ? 37 : LemonadeTheme.sizes.size500
+        #endif
     }
 }
 
@@ -30,6 +86,10 @@ struct LemonadeSpinner_Previews: PreviewProvider {
     static var previews: some View {
         VStack(spacing: 24) {
             LemonadeUi.Spinner()
+
+            LemonadeUi.Spinner(size: .large)
+
+            LemonadeUi.Spinner(size: .xxLarge)
 
             LemonadeUi.Spinner(
                 tint: LemonadeTheme.colors.content.contentBrand


### PR DESCRIPTION
# Summary

The Compose `Spinner` takes a `LemonadeAssetSize` and the Figma component offers five sizes, but the SwiftUI one took only a `tint`. A design any larger than the default could not be built on iOS at all.

This came to light while mapping Spinner for Code Connect: four of the five Figma sizes had nothing to map onto, so the snippet had to say the parameter did not exist. It is the only case found so far where the **two platforms disagree with each other** rather than with Figma — every other gap was Figma offering something neither side had built.

## How it sizes

`ProgressView` only draws at a fixed size per control size, and `scaleEffect` stretches its bitmap, so scaling it up blurs it. Each size picks the closest native control size and scales from there: `.regular` (20pt) up to `.medium`, `.large` (37pt) above it. macOS draws both at 32pt, so there every size scales from that.

```swift
ProgressView()
    .controlSize(size.controlSize)
    .tint(tint)
    .scaleEffect(size.value / size.controlSize.spinnerDimension)
    .frame(width: size.value, height: size.value)
```

That keeps the native iOS spinner and limits upscaling to 1.5× at the largest size, down from 2.8× when every size scaled from 20pt. `LemonadeSpinnerSize` mirrors the Compose `LemonadeAssetSize` values, so the same design resolves to the same dimension on both platforms.

## Figma component

https://www.figma.com/design/91S16rhVrl5wivqV66fNjm/?node-id=7132-127

## Screenshot

A Sizes section is added to the sample app's Spinner screen, showing XS through 4XL side by side.

## How to test

```bash
cd swiftui && swift build && swift test
```

Then run the sample app and open **Spinner** — the new Sizes row should show eight spinners of increasing size, and the existing Default, Custom Tint and Loading Buttons sections should be unchanged.

## Notes for reviewers

- **Source-compatible.** `size` is defaulted and precedes `tint`, so every existing `LemonadeUi.Spinner()` and `LemonadeUi.Spinner(tint:)` call still compiles — including the ones inside `Button`, `IconButton` and `Toast`, which the build exercises.
- The enum carries all eight Compose sizes, not just the five Figma draws, so the two platforms' size vocabularies stay identical.

## API Dump

No public API changes.

